### PR TITLE
add defaults for group auth in group_based_auth.py

### DIFF
--- a/pheweb/serve/group_based_auth.py
+++ b/pheweb/serve/group_based_auth.py
@@ -6,22 +6,33 @@ from collections import defaultdict
 from googleapiclient.discovery import build
 from google.oauth2 import service_account
 
-group_name = conf.group_auth['GROUP']
-service_account_file = conf.group_auth['SERVICE_ACCOUNT_FILE']
-delegated_account = conf.group_auth['DELEGATED_ACCOUNT']
+if conf["authentication"]:
+    group_name = conf.group_auth['GROUP']
+    service_account_file = conf.group_auth['SERVICE_ACCOUNT_FILE']
+    delegated_account = conf.group_auth['DELEGATED_ACCOUNT']
 
-service_account_scopes = [
-    'https://www.googleapis.com/auth/admin.directory.group.readonly',
-    'https://www.googleapis.com/auth/admin.directory.user.readonly',
-    'https://www.googleapis.com/auth/admin.directory.group.member.readonly'
-]
+    service_account_scopes = [
+        'https://www.googleapis.com/auth/admin.directory.group.readonly',
+        'https://www.googleapis.com/auth/admin.directory.user.readonly',
+        'https://www.googleapis.com/auth/admin.directory.group.member.readonly'
+    ]
 
-# set credentials
-creds = service_account.Credentials.from_service_account_file(service_account_file, scopes=service_account_scopes)
-delegated_creds = creds.with_subject(delegated_account)
-services = defaultdict( lambda: build('admin', 'directory_v1', credentials=delegated_creds) )
+    # set credentials
+    creds = service_account.Credentials.from_service_account_file(service_account_file, scopes=service_account_scopes)
+    delegated_creds = creds.with_subject(delegated_account)
+    services = defaultdict( lambda: build('admin', 'directory_v1', credentials=delegated_creds) )
 
-whitelist = conf.login['whitelist'] if 'whitelist' in conf.login.keys() else []
+    whitelist = conf.login['whitelist'] if 'whitelist' in conf.login.keys() else []
+
+else:
+    group_name = None
+    service_account_file = None
+    delegated_account = None
+    service_account_scopes = None
+    creds = None
+    delegated_creds = None
+    services = None
+    whitelist = None
 
 def get_all_members(group_name):
     all = services[threading.get_ident()].members().list(groupKey=group_name).execute()


### PR DESCRIPTION
Fixes #81 by checking if authentication is set, and if not, setting group auth global variables to none.
At some point, it might be preferable to get rid of the global variables, and replace them with a separate group auth thing, be it class or something else. 
Another way of solving #81 would be giving it default values in the `_ensure_conf`-function in [conf_utils.py](https://github.com/FINNGEN/pheweb/blob/master/pheweb/conf_utils.py#L79-L130), but this was simpler.
Better solutions are of course accepted.