### PR TITLE
support non-existing autoreporting backend in frontend

### DIFF
--- a/pheweb/serve/react/js/components/Pheno.js
+++ b/pheweb/serve/react/js/components/Pheno.js
@@ -81,11 +81,17 @@ class Pheno extends React.Component {
 	getGroup(phenocode,locus_id) {
 	fetch('/api/autoreport_variants/'+phenocode+'/'+locus_id)
 		.then(this.resp_json)
-		.then(response => {
+		.then(response => {response?
 			this.setState({
 				locus_groups: {
 					...this.state.locus_groups,
 					[locus_id]:response
+				}
+			}):
+			this.setState({
+				locus_groups: {
+					...this.state.locus_groups,
+					[locus_id]:[]
 				}
 			})
 		})
@@ -95,12 +101,17 @@ class Pheno extends React.Component {
     getCredibleSets(phenocode) {
 	fetch('/api/autoreport/' + phenocode)
 	    .then(this.resp_json)
-	    .then(response => {
+	    .then(response => response ? 
 		this.setState({
 		    credibleSets: response,
 		    selectedTab: response.length == 0 ? 1 : 0
 		})
-	    })
+		:
+		this.setState({
+		    credibleSets: [],
+		    selectedTab: 1
+		})
+		)
 	    .catch(this.error_alert)
     }
 

--- a/pheweb/serve/react/js/components/Pheno.js
+++ b/pheweb/serve/react/js/components/Pheno.js
@@ -88,12 +88,7 @@ class Pheno extends React.Component {
 					[locus_id]:response
 				}
 			}):
-			this.setState({
-				locus_groups: {
-					...this.state.locus_groups,
-					[locus_id]:[]
-				}
-			})
+			0
 		})
 		.catch(this.error_alert)
 	}


### PR DESCRIPTION
In case backend has no autoreportingDAO, it sends a None for a response.
This change makes the frontend getter functions work with that.