### PR TITLE
build: fails installing et_xmlfile

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,33 +1,44 @@
-FROM debian:9
+FROM debian:10
 
 # can change this in k8s deployment yaml to serve from another directory
 ENV PHEWEB_DIR /mnt/nfs/pheweb/r6
 
+# create and setup the en_US.UTF-8 locale
+RUN apt-get upgrade --yes && apt-get update --yes && apt-get install locales --yes
+RUN echo "LC_ALL=en_US.UTF-8" >> /etc/environment
+RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
+RUN echo "LANG=en_US.UTF-8" > /etc/locale.conf
+RUN locale-gen en_US && locale-gen en_US.UTF-8
 ENV LC_CTYPE en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 
+# install nodejs
 RUN apt-get update && apt-get install curl software-properties-common --yes && \
     curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
     apt-get install nodejs --yes
 
+# install cloudsql
 RUN apt-get update && apt-get install --no-install-recommends texlive wget --yes && \
     wget --no-check-certificate https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 -O /usr/local/bin/cloud_sql_proxy && \
     chmod +x /usr/local/bin/cloud_sql_proxy
 
+# copy pheweb source
 ADD . /pheweb
 
-RUN apt-get update && apt-get install default-libmysqlclient-dev git python3-pip libffi-dev libz-dev libssl-dev libbz2-dev liblzma-dev --yes --fix-missing && \
-    pip3 install cython && \
-    pip3 install pip --upgrade && \
-    pip3 install /pheweb && \
-    apt-get purge git --yes
 
+# install python packages and perquisites
+RUN apt-get update && apt-get install default-libmysqlclient-dev git python3-pip libffi-dev libz-dev libssl-dev libbz2-dev liblzma-dev --yes --fix-missing && \
+     python3 -m pip install cython && \
+     python3 -m pip install pip==20.1.1 --upgrade && \
+     python3 -m pip install /pheweb && \
+     python3 -m pip freeze && \
+     apt-get purge git --yes
 
 # create react js bundle
 RUN cd /pheweb/pheweb/serve/react && \
     npm install && node_modules/webpack/bin/webpack.js --config webpack.prod.js && \
-    mv /pheweb/pheweb/serve/static/bundle.js /usr/local/lib/python3.5/dist-packages/pheweb/serve/static/ && \
+    mv /pheweb/pheweb/serve/static/bundle.js /usr/local/lib/python3.7/dist-packages/pheweb/serve/static/ && \
     rm -r /pheweb
 
 EXPOSE 8080

--- a/pheweb/serve/react/package-lock.json
+++ b/pheweb/serve/react/package-lock.json
@@ -5767,9 +5767,9 @@
       "integrity": "sha512-De+lPAxEcpxvqPTyZAXELNpRZXABRxf+uL/rSykstQhzj/B0l1150G/ExIIxKc16lI89Hgz81J0BHAcbTqK49g=="
     },
     "elliptic": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
-      "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
       "requires": {
         "bn.js": "^4.4.0",
         "brorand": "^1.0.1",
@@ -11580,9 +11580,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash.assign": {
       "version": "4.2.0",
@@ -12020,9 +12020,9 @@
       }
     },
     "node-forge": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-      "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
       "dev": true
     },
     "node-int64": {
@@ -14180,12 +14180,12 @@
       "dev": true
     },
     "selfsigned": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-      "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+      "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "dev": true,
       "requires": {
-        "node-forge": "0.9.0"
+        "node-forge": "^0.10.0"
       }
     },
     "semver": {

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
         'scipy~=1.0',
         'numpy~=1.14',
         'requests[security]~=2.18',
-        'cryptography~=2.3',
+        'cryptography~=3.2',
         'idna~=2.6',
         'gunicorn~=19.7',
         'boltons~=18.0',


### PR DESCRIPTION
The latest version of pip resolves to a version of et_xmlfile that fails to
install.  The workaround is to pin pip to 20.1.1.  Debian is upgraded from
version 9 to 10.  This results in python 3.7 being used instead of 3.5, which
has been 'end of life.'  npm dependencies have been updated for critical
fixes.

Ref : #87