### PR TITLE
Add compatibility for Pan-ukbb external data, make column names configurable.

### DIFF
--- a/config/config.r5.py
+++ b/config/config.r5.py
@@ -36,12 +36,40 @@ database_conf = (
         }
     }, {
         "externalresultmatrix": {
-            "ExternalMatrixResultDao": {"matrix":"/mnt/nfs/ukbb_neale/matrix.tsv.gz", "metadatafile":"/mnt/nfs/ukbb_neale/ukbb_r1_match_pheno_dup_correct_simple_meta.tsv"}
+            "ExternalMatrixResultDao": {"matrix":"/mnt/nfs/ukbb_neale/matrix.tsv.gz", "metadatafile":"/mnt/nfs/ukbb_neale/ukbb_r1_match_pheno_dup_correct_simple_meta.tsv",
+            "column_names":{"pval":"pval","beta":"beta"}}
         }
     }, {
         "externalresult": {
-            "ExternalFileResultDao": {"manifest":"/mnt/nfs/ukbb_neale/ukbb_r1_match_pheno_dup_correct_ssd.tsv"}
+            "ExternalFileResultDao": {"manifest":"/mnt/nfs/ukbb_neale/ukbb_r1_match_pheno_dup_correct_ssd.tsv",
+            "chrom_is_numeric":False,
+                "column_names":{
+                    "chr":"achr38",
+                    "pos":"apos38",
+                    "ref":"REF",
+                    "alt":"ALT",
+                    "pval":"pval",
+                    "beta":"beta",
+                    }}
         }
+    # }, { #PAN-UKBB
+    #    "externalresultmatrix": {
+    #        "ExternalMatrixResultDao": {"matrix":"/mnt/nfs/pan_ukbb/pan_ukbb_matrix.tsv.gz", "metadatafile":"/mnt/nfs/pan_ukbb/single_file_manifest.tsv",
+    #        "column_names":{"pval":"pval_EUR","beta":"beta_EUR"}}
+    #    }
+    # }, {
+    #    "externalresult": {
+    #        "ExternalFileResultDao": {"manifest":"/mnt/nfs/pan_ukbb/single_file_manifest.tsv",
+    #        "chrom_is_numeric":True,
+    #            "column_names":{
+    #                "chr":"#chr",
+    #                "pos":"pos",
+    #                "ref":"ref",
+    #                "alt":"alt",
+    #                "pval":"pval_EUR",
+    #                "beta":"beta_EUR",
+    #                }}
+    #    }
     }, {
         "coding": {
             "TSVCodingDao": {"data":"/mnt/nfs/coding/r5/r5_coding_web.txt"}

--- a/config/config.r5.py
+++ b/config/config.r5.py
@@ -37,7 +37,14 @@ database_conf = (
     }, {
         "externalresultmatrix": {
             "ExternalMatrixResultDao": {"matrix":"/mnt/nfs/ukbb_neale/matrix.tsv.gz", "metadatafile":"/mnt/nfs/ukbb_neale/ukbb_r1_match_pheno_dup_correct_simple_meta.tsv",
-            "column_names":{"pval":"pval","beta":"beta"}}
+            "column_names":{
+               "chr":"#chr",
+               "pos":"pos",
+               "ref":"ref",
+               "alt":"alt",
+               "pval":"pval_EUR",
+               "beta":"beta_EUR"
+           }}
         }
     }, {
         "externalresult": {
@@ -55,7 +62,14 @@ database_conf = (
     # }, { #PAN-UKBB
     #    "externalresultmatrix": {
     #        "ExternalMatrixResultDao": {"matrix":"/mnt/nfs/pan_ukbb/pan_ukbb_matrix.tsv.gz", "metadatafile":"/mnt/nfs/pan_ukbb/single_file_manifest.tsv",
-    #        "column_names":{"pval":"pval_EUR","beta":"beta_EUR"}}
+    #        "column_names":{
+    #            "chr":"#chr",
+    #            "pos":"pos",
+    #            "ref":"ref",
+    #            "alt":"alt",
+    #            "pval":"pval_EUR",
+    #            "beta":"beta_EUR"
+    #        }}
     #    }
     # }, {
     #    "externalresult": {

--- a/pheweb/serve/react/js/tables.js
+++ b/pheweb/serve/react/js/tables.js
@@ -295,12 +295,17 @@ const phenoTableCols = {'GBMA': [...phenoTableCommonCols[0], ...phenoTableCommon
     minWidth: 110
 }, ...phenoTableCommonCols[1],
 {
-    Header: () => (<span title="UKBB Neale lab result" style={{textDecoration: 'underline'}}>UKBB</span>),
+    Header: () => (<span title="UKBB Neale lab p-value" style={{textDecoration: 'underline'}}>UKBB pval</span>),
+    accessor: 'ukbb',
+    filterMethod: (filter, row) => row[filter.id] < filter.value,
+    Cell: props => props.original.ukbb ? Number.parseFloat(props.original.ukbb.pval).toPrecision(3) : 'NA',
+    minWidth: 110
+},
+{
+    Header: () => (<span title="UKBB Neale lab beta" style={{textDecoration: 'underline'}}>UKBB beta</span>),
     accessor: 'UKBB',
-    filterMethod: (filter, row) => row[filter.id] < +filter.value,
-    Cell: props => props.original.ukbb ? <div>{(Number(props.original.ukbb.beta) >= 0) ? <span style={{color: 'green', float: 'left', paddingRight: '5px'}} className="glyphicon glyphicon-triangle-top" aria-hidden="true"></span> :
-					       (Number(props.original.ukbb.beta) < 0) ? <span style={{color: 'red', float: 'left', paddingRight: '5px'}} className="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span> :
-					       <span></span>} {Number(props.original.ukbb.pval).toExponential(1)}</div> : 'NA',
+    filterMethod: (filter, row) => row[filter.id] < filter.value,
+    Cell: props => props.original.ukbb ? Number.parseFloat(props.original.ukbb.beta).toPrecision(3) : 'NA',
     minWidth: 110
 }],
 'FINNGEN_QUANT': [...phenoTableCommonCols[0],{
@@ -446,14 +451,19 @@ const csTableCols = [{
     sortMethod: stringToCountSorter,
     Cell: props => <div><span title={props.value}>{props.value.split(";").filter(x=>x!=="NA").length}</span></div>,
     minWidth: 60,
-}, {
-    Header: () => (<span title="UKBB Neale lab result" style={{textDecoration: 'underline'}}>UKBB</span>),
+},{
+    Header: () => (<span title="UKBB Neale lab p-value" style={{textDecoration: 'underline'}}>UKBB pval</span>),
     accessor: 'ukbb_pval',
-    sortMethod: naSorter,
-    Cell: props => props.value != "NA" ? <div>{(Number(props.original.ukbb_beta) >= 0) ? <span style={{color: 'green', float: 'left', paddingRight: '5px'}} className="glyphicon glyphicon-triangle-top" aria-hidden="true"></span> :
-					       (Number(props.original.ukbb_beta) < 0) ? <span style={{color: 'red', float: 'left', paddingRight: '5px'}} className="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span> :
-					       <span></span>} {Number(props.value).toExponential(1)}</div> : props.value,
-    minWidth: 60,
+    filterMethod: (filter, row) => row[filter.id] < filter.value,
+    Cell: props => isNaN(props.value)? 'NA': props.value.toPrecision(3),
+    minWidth: 110
+},
+{
+    Header: () => (<span title="UKBB Neale lab beta" style={{textDecoration: 'underline'}}>UKBB beta</span>),
+    accessor: 'ukbb_beta',
+    filterMethod: (filter, row) => row[filter.id] < filter.value,
+    Cell: props => isNaN(props.value)? 'NA': props.value.toPrecision(3),
+    minWidth: 110
 }
 
 ]

--- a/pheweb/serve/server.py
+++ b/pheweb/serve/server.py
@@ -427,7 +427,8 @@ def gene_report(genename):
         if( ukbdat is not None):
             pval = float( ukbdat["pval"] )
             beta = float( ukbdat["beta"] )
-            ukbline = " \\newline UKBB: " + (" $\\Uparrow$ " if beta>=0 else " $\Downarrow$ ") + ", p:" + "{:.2e}".format(pval)
+            OR = math.exp(beta)
+            ukbline = " \\newline UKBB: " + (" $\\Uparrow$ " if beta>=0 else " $\Downarrow$ ") + "OR: {:.2f}".format(OR) + ", p: " + "{:.2e}".format(pval)
         return ukbline
 
     for var in func_vars:

--- a/pheweb/serve/server_jeeves.py
+++ b/pheweb/serve/server_jeeves.py
@@ -28,16 +28,7 @@ class ServerJeeves(object):
         self.lof_dao = self.dbs_fact.get_lof_dao()
         self.result_dao = self.dbs_fact.get_result_dao()
         # UKBB dao
-        ukbb_availability = self.dbs_fact.get_UKBB_availability()
-        if ukbb_availability["externalresultmatrix"] and ukbb_availability["externalresult"]:
-            self.ukbb_dao = self.dbs_fact.get_UKBB_dao(False)
-            self.ukbb_matrixdao = self.dbs_fact.get_UKBB_dao(True)
-        elif ukbb_availability["externalresultmatrix"]:
-            self.ukbb_dao = self.dbs_fact.get_UKBB_dao(True)
-            self.ukbb_matrixdao = self.ukbb_dao
-        else:
-            self.ukbb_dao = self.dbs_fact.get_UKBB_dao(False)
-            self.ukbb_matrixdao = self.ukbb_dao
+        self.ukbb_dao, self.ukbb_matrixdao = self.dbs_fact.get_UKBB_objects()
         self.coding_dao = self.dbs_fact.get_coding_dao()
         self.chip_dao = self.dbs_fact.get_chip_dao()
         self.finemapping_dao = self.dbs_fact.get_finemapping_dao()

--- a/pheweb/serve/server_jeeves.py
+++ b/pheweb/serve/server_jeeves.py
@@ -27,8 +27,17 @@ class ServerJeeves(object):
         self.gnomad_dao = self.dbs_fact.get_gnomad_dao()
         self.lof_dao = self.dbs_fact.get_lof_dao()
         self.result_dao = self.dbs_fact.get_result_dao()
-        self.ukbb_dao = self.dbs_fact.get_UKBB_dao()
-        self.ukbb_matrixdao =self.dbs_fact.get_UKBB_dao(True)
+        # UKBB dao
+        ukbb_availability = self.dbs_fact.get_UKBB_availability()
+        if ukbb_availability["externalresultmatrix"] and ukbb_availability["externalresult"]:
+            self.ukbb_dao = self.dbs_fact.get_UKBB_dao(False)
+            self.ukbb_matrixdao = self.dbs_fact.get_UKBB_dao(True)
+        elif ukbb_availability["externalresultmatrix"]:
+            self.ukbb_dao = self.dbs_fact.get_UKBB_dao(True)
+            self.ukbb_matrixdao = self.ukbb_dao
+        else:
+            self.ukbb_dao = self.dbs_fact.get_UKBB_dao(False)
+            self.ukbb_matrixdao = self.ukbb_dao
         self.coding_dao = self.dbs_fact.get_coding_dao()
         self.chip_dao = self.dbs_fact.get_chip_dao()
         self.finemapping_dao = self.dbs_fact.get_finemapping_dao()

--- a/pheweb/serve/templates/gene.html
+++ b/pheweb/serve/templates/gene.html
@@ -87,7 +87,8 @@
                 <th style="width: 6%;">OR</th>
                 <th style="width: 7%;">p-value</th>
                 <th style="width: 7%;">number of cases</th>
-                <th style="width: 9%;">UKBB</th>
+                <th style="width: 9%;">UKBB pval</th>
+                <th style="width: 9%;">UKBB OR</th>
                 <th style="width: 7%;">UKBB number of cases</th>
               </tr>
             </thead>
@@ -250,7 +251,8 @@
     <td><%= _.template($('#beta-template-dir').html())({assoc: p.assoc}) + Math.exp(p.assoc.beta).toFixed(2) %></td>
     <td><%= p.assoc.pval.toExponential(1) %></td>
     <td style="text-align: right;"><%= p.pheno.num_cases %></td>
-    <td><%= p.assoc.matching_results.ukbb ? _.template($('#beta-template-dir').html())({assoc: p.assoc.matching_results.ukbb}) + '<span>' + Number(p.assoc.matching_results.ukbb.pval).toExponential(1) + '</span>'  : 'NA' %></td>
+    <td><%= p.assoc.matching_results.ukbb ? Math.exp(Number(p.assoc.matching_results.ukbb.pval)).toPrecision(3) + '</span>'  : 'NA' %></td>
+    <td><%= p.assoc.matching_results.ukbb ? _.template($('#beta-template-dir').html())({assoc: p.assoc.matching_results.ukbb}) + Math.exp(Number(p.assoc.matching_results.ukbb.beta)).toPrecision(3) + '</span>'  : 'NA' %></td>
     <td><%= p.assoc.matching_results.ukbb ? p.assoc.matching_results.ukbb.n_cases:"NA"  %></td>
   </tr>
   <% } else { %>
@@ -268,7 +270,8 @@
     <td><%= _.template($('#beta-template-dir').html())({assoc: p.assoc}) +  Math.exp(p.assoc.beta).toPrecision(2) %></td>
     <td><%= p.assoc.pval.toExponential(1) %></td>
     <td style="text-align: right;"><%= p.pheno.num_cases %></td>
-    <td><%= p.assoc.matching_results.ukbb ? _.template($('#beta-template-dir').html())({assoc: p.assoc.matching_results.ukbb}) + '<span>p:' + Number(p.assoc.matching_results.ukbb.pval).toExponential(1) +'</span>' : 'NA' %></td>
+    <td><%= p.assoc.matching_results.ukbb ? Math.exp(Number(p.assoc.matching_results.ukbb.pval)).toPrecision(3) + '</span>'  : 'NA' %></td>
+    <td><%= p.assoc.matching_results.ukbb ? _.template($('#beta-template-dir').html())({assoc: p.assoc.matching_results.ukbb}) + Math.exp(Number(p.assoc.matching_results.ukbb.beta)).toPrecision(3) + '</span>'  : 'NA' %></td>
     <td><%= p.assoc.matching_results.ukbb ? p.assoc.matching_results.ukbb.n_cases:"NA"  %></td>
   </tr>
   <% } %>
@@ -308,7 +311,7 @@
     <td><table> <%= v.significant_phenos
 	    .sort(function(pheno1, pheno2) { return pheno1.pval - pheno2.pval })
 	    .map(function(pheno) {
-            return '<tr class="gene_func_var_tab"> <tr> <td class="gene_func_var_row" width="100px">' + (pheno.matching_results.ukbb ? _.template($('#beta-template-dir').html())({assoc:pheno.matching_results.ukbb}) + '<span>p:' + Number(pheno.matching_results.ukbb.pval).toExponential(1) + '</span>':"NA" ) +
+            return '<tr class="gene_func_var_tab"> <tr> <td class="gene_func_var_row" width="100px"> '  +  (pheno.matching_results.ukbb ? "OR ": "")  + (pheno.matching_results.ukbb ?  _.template($('#beta-template-dir').html())({assoc:pheno.matching_results.ukbb}) + Math.exp(pheno.matching_results.ukbb.beta).toPrecision(2) + '<br> <span>p-val:' + Number(pheno.matching_results.ukbb.pval).toExponential(1) + '</span>':"NA" ) +
                 ' </td> </tr>'
 	    }).join(" ") %>
         </table>

--- a/pheweb/serve/templates/gene_report.tex
+++ b/pheweb/serve/templates/gene_report.tex
@@ -43,7 +43,7 @@ Variant & rsid & Consequence & MAF & MAF FIN & MAF NFE & N phenos p\textless((( 
 \newpage
 \begin{landscape}
 \section{ Top associations in the gene region }
-\begin{longtable}{ >{\RaggedRight}p{3cm}|>{\RaggedRight}p{3cm}|c|c|c|c|c|c|c }
+\begin{longtable}{ >{\RaggedRight}p{3cm}|>{\RaggedRight}p{3cm}|c|c|c|c|c|c|p{3cm} }
 \caption{ Phenotype associations p\textless (((gene_top_assoc_threshold))) }\\
     Variant & pheno & cases & controls & MAF case & MAF control & OR & p-value & UKBB \\
 \hline


### PR DESCRIPTION
This PR aims to make newly matched pan-ukbb data usable in the pheweb browser.

## Changes
- Make external data column names configurable
    - For matrix data, pval and beta are configurable, single files have c:p:r:a + pval and beta
- Add both pval and beta to phenoview tables
    - Beta should now be usable as pan-ukbb scans were made with saige
- In case only matrix DAO or file DAO is available, use that for both operations, otherwise use both (previously matrix DAO was saved to jeeves.ukbb_matrix_dao and file DAO was saved to jeeves.ukbb_dao, so you had to have both for full ukbb functionality. Now they are saved similarly, but if one is missing then either ukbb_matrix_dao or okbb_dao is pointed to be the existing DAO.)
- Example config for pan-ukbb data in config.r5.py
## Possible changes to be made before merge
- Due to the fact that our data has changed quite a lot since R1 when the previous ukbb data was created (remove chr from vars, change to numerical chromosomes from XYMT), the data differ by quite a bit. I had to add a few variables and checks to the DAO initialization & configs. We should see whether this could be done better.
    - file DAO config has `chrom_is_numeric` flag for whether chromosomes are XYMT or 23,24,25
    - matrix DAO has `column_names` dict for pval and beta names, file DAO has c:p:r:a also
    - Whether chrom has "chr" prefix is figured out at runtime 
-  Config file format could be changed
- Frontend table can be prettier

R6 data with pan-ukbb data can be seen in dev.finngen.fi