### PR TITLE
Hide gene report generation button

### DIFF
--- a/pheweb/serve/templates/gene.html
+++ b/pheweb/serve/templates/gene.html
@@ -45,10 +45,12 @@
     <span id="gnomad-link"></span>
     <span id="opentarget-link"></span>
     </p>
+    <!--
     <div class='btn' style='display:inline-block; padding-left: 0px'>
         <span class='dl-link btn-primary btn aligned' id ="genereport" role='button'> Generate gene report</span>
         <span id="reportloader" class="loader aligned"></span>
     </div>
+    -->
     <p id="genereport-errorbox" class="errorbox" style="display:none">error</p>
 
   </div>


### PR DESCRIPTION
Hides the broken gene report DL button mentioned in #103 (just commenting it out)

