### PR TITLE
fix:autocomplete missing variant

### DIFF
--- a/pheweb/serve/components/autocomplete/sqlite_dao.py
+++ b/pheweb/serve/components/autocomplete/sqlite_dao.py
@@ -100,10 +100,10 @@ class SQLiteAutocompleter(object):
                         display = cpra_display
                     else:
                         display = '{} ({})'.format(cpra_display, ','.join(row['rsid'] for row in rowlist))
-                        yield {
-                            'variant' : cpra,
-                            'display' : display
-                        }
+                    yield {
+                        'variant' : cpra,
+                        'display' : display
+                    }
 
     def _autocomplete_rsid(self, query:str) -> Iterator[Dict[str,str]]:
         key = query.lower()


### PR DESCRIPTION
resolved an indention problem that was causing variants not to show
up in the auto complete if the rsid's were missing.