### PR TITLE
Make credset table filters more useful

### DIFF
--- a/pheweb/serve/react/js/tables.js
+++ b/pheweb/serve/react/js/tables.js
@@ -411,14 +411,15 @@ const phenoTableCols = {'GBMA': [...phenoTableCommonCols[0], ...phenoTableCommon
 const csTableCols = [{
     Header: () => (<span title="variant with highest PIP in the credible set" style={{textDecoration: 'underline'}}>top PIP variant</span>),
     accessor: 'locus_id',
-    filterMethod: (filter,row) => (filter.value == row[filter.id].replace("chr","").replace(/_/g,":"))|(filter.value == row[filter.id]),
+    filterMethod: (filter,rows) => {const fstr = "chr"+filter.value.replace("chr","").replace(/:/g,"_");return matchSorter(rows,fstr,{keys:[row => row[filter.id]]})},
+    filterAll:true,
     Cell: props => (<a href={"/region/" + props.original.phenocode+"/"+regionBuilder(props.value,250000)} target="_blank">{props.value.replace("chr","").replace(/_/g,":")}</a>),
     //width: Math.min(270, 270/maxTableWidth*window.innerWidth),
     minWidth: 60,
 },{
     Header: () => (<span title="CS quality" style={{textDecoration: 'underline'}}>CS quality</span>),
     accessor: 'good_cs',
-    filterMethod: (filter,row) => filter.value == row[filter.id],
+    filterMethod: (filter,row) => (filter,row) => (filter.value=="true"?1:(filter.value=="false"?0:2)) == row[filter.id],
     Cell: props => String(props.value),
     minWidth: 60,
 }, {
@@ -450,7 +451,8 @@ const csTableCols = [{
 },{
     Header: () => (<span title="Lead Variant Gene" style={{textDecoration: 'underline'}}>Lead Variant Gene</span>),
     accessor: 'lead_most_severe_gene',
-    filterMethod: (filter,row) => filter.value == row[filter.id],
+    filterMethod: (filter,rows) => matchSorter(rows,filter.value,{keys:[row=>row[filter.id]]}),
+    filterAll: true,
     Cell: props => props.value != "NA" ? (<a href={"/gene/" + props.value} target="_blank">{props.value}</a>):"NA",
     minWidth: 50,
 }, {

--- a/pheweb/serve/react/js/tables.js
+++ b/pheweb/serve/react/js/tables.js
@@ -46,6 +46,11 @@ const stringToCountSorter = (a,b) => {
     return d - c
 }
 
+const stringToCount= (a) => {
+    a.split(";").filter(x=> x != 'NA').length
+    return a
+}
+
 const tofixed = (v,n) => {
     return typeof(v) == typeof(0) ? v.toFixed(n) : v
 }
@@ -406,6 +411,7 @@ const phenoTableCols = {'GBMA': [...phenoTableCommonCols[0], ...phenoTableCommon
 const csTableCols = [{
     Header: () => (<span title="variant with highest PIP in the credible set" style={{textDecoration: 'underline'}}>top PIP variant</span>),
     accessor: 'locus_id',
+    filterMethod: (filter,row) => filter.value == row[filter.id],
     Cell: props => (<a href={"/region/" + props.original.phenocode+"/"+regionBuilder(props.value,250000)} target="_blank">{props.value.replace("chr","").replace(/_/g,":")}</a>),
     //width: Math.min(270, 270/maxTableWidth*window.innerWidth),
     minWidth: 60,
@@ -418,6 +424,7 @@ const csTableCols = [{
 }, {
     Header: () => (<span title="chromosome" style={{textDecoration: 'underline'}}>chromosome</span>),
     accessor: 'chrom',
+    filterMethod: (filter,row) => filter.value == row[filter.id],
     Cell: props => props.value,
     minWidth: 50,
 }, { ... pval_column , minWidth: 50,
@@ -425,13 +432,13 @@ const csTableCols = [{
 }, {
     Header: () => (<span title="effect size (beta)" style={{textDecoration: 'underline'}}>effect size (beta)</span>),
     accessor: 'lead_beta',
-    filterMethod: (filter, row) => Math.abs(row[filter.id]) < +filter.value,
+    filterMethod: (filter, row) => Math.abs(row[filter.id]) >= +filter.value,
     Cell: props => tofixed(props.value,3),
     minWidth: 50,
 }, {
     Header: () => (<span title="Finnish Enrichment" style={{textDecoration: 'underline'}}>Finnish Enrichment</span>),
     accessor: 'lead_enrichment',
-    filterMethod: (filter, row) => Math.abs(row[filter.id]) < +filter.value,
+    filterMethod: (filter, row) => Math.abs(row[filter.id]) >= +filter.value,
     Cell: props => tofixed(props.value,3),
     minWidth: 50,
 },{
@@ -443,36 +450,41 @@ const csTableCols = [{
 },{
     Header: () => (<span title="Lead Variant Gene" style={{textDecoration: 'underline'}}>Lead Variant Gene</span>),
     accessor: 'lead_most_severe_gene',
+    filterMethod: (filter,row) => filter.value == row[filter.id],
     Cell: props => props.value != "NA" ? (<a href={"/gene/" + props.value} target="_blank">{props.value}</a>):"NA",
     minWidth: 50,
 }, {
     Header: () => (<span title="number of coding variants in the credible set. Tooltip shows variant name, most severe consequence, R² to lead variant" style={{textDecoration: 'underline'}}># coding in cs</span>),
     accessor: 'functional_variants_strict',
     sortMethod: stringToCountSorter,
+    filterMethod: (filter,row) => stringToCount(row[filter.id]) >= filter.value,
     Cell: props => <div><span title={truncateString(props.value,4)}>{props.value.split(";").filter(x=>x!=="NA").length}</span></div>,
     minWidth: 40
 }, {
     Header: () => (<span title="# Credible set variants" style={{textDecoration: 'underline'}}># credible variants</span>),
     accessor: 'credible_set_variants',
     sortMethod: stringToCountSorter,
+    filterMethod: (filter,row) => stringToCount(row[filter.id]) >= filter.value,
     Cell: props => <div><span title={truncateString(props.value,4)}>{props.original.cs_size}</span></div>,
     minWidth: 50,
 },{
     Header: () => (<span title="Credible set Log10 bayes factor" style={{textDecoration: 'underline'}}>Credible set bayes factor (log10)</span>),
     accessor: 'cs_log_bayes_factor',
-    filterMethod: (filter, row) => Math.abs(row[filter.id]) < +filter.value,
+    filterMethod: (filter, row) => Math.abs(row[filter.id]) >= +filter.value,
     Cell: props => tofixed(props.value,3),
     minWidth: 50,
 }, {
     Header: () => (<span title="CS matching Traits" style={{textDecoration: 'underline'}}>CS matching Traits</span>),
     accessor: 'all_traits_strict',
     sortMethod: stringToCountSorter,
+    filterMethod: (filter,row) => stringToCount(row[filter.id]) >= filter.value,
     Cell: props => <div><span title={props.value}>{props.value.split(";").filter(x=>x!=="NA").length}</span></div>,
     minWidth: 60,
 }, {
     Header: () => (<span title="LD Partner matching Traits" style={{textDecoration: 'underline'}}>LD Partner Traits</span>),
     accessor: 'all_traits_relaxed',
     sortMethod: stringToCountSorter,
+    filterMethod: (filter,row) => stringToCount(row[filter.id]) >= filter.value,
     Cell: props => <div><span title={props.value}>{props.value.split(";").filter(x=>x!=="NA").length}</span></div>,
     minWidth: 60,
 },
@@ -504,17 +516,19 @@ minWidth: 60,
 }, {
 Header: () => (<span title="effect size" style={{textDecoration: 'underline'}}>effect size</span>),
 accessor: 'beta',
-filterMethod: (filter, row) => Math.abs(row[filter.id]) < +filter.value,
+filterMethod: (filter, row) => Math.abs(row[filter.id]) >= +filter.value,
 Cell: props => props.value,
 minWidth: 50,
 }, {
 Header: () => (<span title="Gene" style={{textDecoration: 'underline'}}>Gene</span>),
 accessor: 'most_severe_gene',
+filterMethod: (filter, row) => row[filter.id] == +filter.value,
 Cell: props => props.value != "NA" ? (<a href={"/gene/" + props.value} target="_blank">{props.value}</a>):"NA",
 minWidth: 50,
 }, {
 Header: () => (<span title="Consequence" style={{textDecoration: 'underline'}}>Consequence</span>),
 accessor: 'most_severe_consequence',
+filterMethod: (filter, row) => row[filter.id] == +filter.value,
 Cell: props => props.value ,
 minWidth: 50,
 }, {
@@ -538,29 +552,32 @@ minWidth: 40,
 }, {
 Header: () => (<span title="INFO" style={{textDecoration: 'underline'}}>INFO</span>),
 accessor: 'INFO',
-filterMethod: (filter, row) => Math.abs(row[filter.id]) < +filter.value,
+filterMethod: (filter, row) => Math.abs(row[filter.id]) >= +filter.value,
 Cell: optionalFloat,
 minWidth: 40,
 }, {
 Header: () => (<span title="Finnish Enrichment" style={{textDecoration: 'underline'}}>Finnish enrichment</span>),
 accessor: 'enrichment_nfsee',
-filterMethod: (filter, row) => Math.abs(row[filter.id]) < +filter.value,
+filterMethod: (filter, row) => Math.abs(row[filter.id]) >= +filter.value,
 Cell: optionalFloat ,
 minWidth: 50,
 }, {
 Header: () => (<span title="Credible set PIP" style={{textDecoration: 'underline'}}>CS PIP</span>),
 accessor: 'cs_prob',
+filterMethod: (filter, row) => Math.abs(row[filter.id]) >= +filter.value,
 Cell: optionalFloat ,
 minWidth: 40
 }, {
 Header: () => (<span title="Functional Category" style={{textDecoration: 'underline'}}>Functional variant</span>),
 accessor: 'functional_category',
+filterMethod: (filter, row) => row[filter.id] == +filter.value,
 Cell: props => props.value,
 minWidth: 40
 }, {
 Header: () => (<span title="Matching trait" style={{textDecoration: 'underline'}}>Matching trait</span>),
 accessor: 'trait_name',
 sortMethod: stringToCountSorter,
+filterMethod: (filter,row) => stringToCount(row[filter.id]) >= filter.value,
 Cell: props => <div><span title={props.value}>{truncateString(props.value,2)}</span></div>,
 minWidth: 40
 }, {

--- a/pheweb/serve/react/js/tables.js
+++ b/pheweb/serve/react/js/tables.js
@@ -47,8 +47,8 @@ const stringToCountSorter = (a,b) => {
 }
 
 const stringToCount= (a) => {
-    a.split(";").filter(x=> x != 'NA').length
-    return a
+    return a.split(";").filter(x=> x != 'NA').length
+    
 }
 
 const tofixed = (v,n) => {

--- a/pheweb/serve/react/js/tables.js
+++ b/pheweb/serve/react/js/tables.js
@@ -411,7 +411,7 @@ const phenoTableCols = {'GBMA': [...phenoTableCommonCols[0], ...phenoTableCommon
 const csTableCols = [{
     Header: () => (<span title="variant with highest PIP in the credible set" style={{textDecoration: 'underline'}}>top PIP variant</span>),
     accessor: 'locus_id',
-    filterMethod: (filter,row) => filter.value == row[filter.id],
+    filterMethod: (filter,row) => (filter.value == row[filter.id].replace("chr","").replace(/_/g,":"))|(filter.value == row[filter.id]),
     Cell: props => (<a href={"/region/" + props.original.phenocode+"/"+regionBuilder(props.value,250000)} target="_blank">{props.value.replace("chr","").replace(/_/g,":")}</a>),
     //width: Math.min(270, 270/maxTableWidth*window.innerWidth),
     minWidth: 60,


### PR DESCRIPTION
This PR changes the filtering of the CS table in pheno page (e.g. https://r9.finngen.fi/pheno/CARDIAC_ARRHYTM) to be like the following:
```
top PIP variant: matching string, either 1:1:A:C or chr1_1_A_C
CS quality: 1 or 0
chromosome: matching chromosome
p-value: all p-values lower than the filter
-log10(p): all values larger than the filter
effect size(beta): all effects that have abs value larger than filter (e.g. filter 0.1, rows with values larger than 0.1 or smaller than -0.1 are visible)
Finnish Enrichment: values larger than filter are visible
Alternate allele frequency: values lower than filter are left
Lead Variant Gene: matching string
# coding in cs: if amount of coding in cs is larger than filter that row is visible (e.g. filter is 1, only rows with more than one coding variant are visible)
# credible variants: rows with more credible variants than filter are visible
Credible set bayes factor (log10): values larger than filter are visible
CS matching traits: rows with more matching traits than filter value are visible
LD partner traits: rows with more matching traits than filter value are visible
UKBB: No filter
```
Changes still to be made:
- CS quality true/false
- top PIP variant starts with match
- gene starts with match
