### PR TITLE
244 r9 to bstaging

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
 	    }
 	}
     stage('Deploy') {
-            when { branch "origin/master" }
+            when { expression { env.GIT_BRANCH == 'origin/master' } }
 	    steps {
                 withCredentials([file(credentialsId: 'jenkins-sa', variable: 'gcp')]) {
                     sh '''/root/google-cloud-sdk/bin/gcloud auth activate-service-account --key-file=$gcp'''

--- a/deploy/kubernetes/staging-values.yaml
+++ b/deploy/kubernetes/staging-values.yaml
@@ -1,6 +1,6 @@
 # Default values are found in values.yaml
 
-replicaCount: 1
+replicaCount: 3
 
 pheweb:
   cloudSQLCredentialFile: /etc/gcp/cloud-sql-credentials.json


### PR DESCRIPTION
This stops non-master builds on CI server from deploying to staging.
It also increases the number nodes on the staging from 1 to 3.
