### PR TITLE
309 decouple autorep ukbb

### DIFF
--- a/pheweb/serve/data_access/db.py
+++ b/pheweb/serve/data_access/db.py
@@ -1896,20 +1896,15 @@ class AutoreportingDao(AutorepVariantDB):
                     )
                     #join trait cols
                     if "specific_efo_trait_associations_relaxed" in hdr:
-                        all_traits_strict = ";".join(list(filter(
-                            lambda x: x !=  "NA",
-                            [
-                                cols[hdi["specific_efo_trait_associations_strict"]],
-                                cols[hdi["found_associations_strict"]]
-                            ]
-                        )))
-                        all_traits_relaxed = ";".join(list(filter(
-                            lambda x: x !=  "NA",
-                            [
-                                cols[hdi["specific_efo_trait_associations_relaxed"]],
-                                cols[hdi["found_associations_relaxed"]]
-                            ]
-                        )))
+                        merge_func = lambda a,b : ";".join(list(filter(lambda x:x!="NA",[a,b])))
+                        all_traits_strict = merge_func(
+                            cols[hdi["specific_efo_trait_associations_strict"]],
+                            cols[hdi["found_associations_strict"]]
+                        )
+                        all_traits_relaxed = merge_func(
+                            cols[hdi["specific_efo_trait_associations_relaxed"]],
+                            cols[hdi["found_associations_relaxed"]]
+                        )
                         all_traits_strict = "NA" if all_traits_strict == "" else all_traits_strict
                         all_traits_relaxed = "NA" if all_traits_relaxed == "" else all_traits_relaxed
                     else:

--- a/pheweb/serve/data_access/db.py
+++ b/pheweb/serve/data_access/db.py
@@ -1866,8 +1866,8 @@ class AutoreportingDao(AutorepVariantDB):
                         record = {
                             "chrom":cols[hdi["chr"]],
                             "pval":float(cols[hdi["lead_pval"]]),
-                            "lead_enrichment":float(cols[hdi["enrichment"]]),
-                            "lead_af_alt":float(cols[hdi["lead_AF"]]),
+                            "lead_enrichment":float(cols[hdi["enrichment"]]) if cols[hdi["enrichment"]] != "NA" else float("nan"),
+                            "lead_af_alt":float(cols[hdi["lead_AF"]]) if cols[hdi["lead_AF"]] != "NA" else float("nan"),
                             "lead_most_severe_gene":cols[hdi["most_severe_gene"]],
                             
                         }
@@ -1875,8 +1875,8 @@ class AutoreportingDao(AutorepVariantDB):
                         record = {
                             "chrom":cols[hdi["chrom"]],
                             "pval":float(cols[hdi["pval"]]),
-                            "lead_enrichment":float(cols[hdi["lead_enrichment"]]),
-                            "lead_af_alt":float(cols[hdi["lead_af_alt"]]),
+                            "lead_enrichment":float(cols[hdi["lead_enrichment"]]) if cols[hdi["lead_enrichment"]] != "NA" else float("nan"),
+                            "lead_af_alt":float(cols[hdi["lead_af_alt"]]) if cols[hdi["lead_af_alt"]] != "NA" else float("nan"),
                             "lead_most_severe_gene":cols[hdi["lead_most_severe_gene"]],
                         }
                     #common cols
@@ -1890,7 +1890,7 @@ class AutoreportingDao(AutorepVariantDB):
                             "functional_variants_strict":cols[hdi["functional_variants_strict"]],
                             "credible_set_variants":cols[hdi["credible_set_variants"]],
                             "cs_size":int(cols[hdi["cs_size"]]),
-                            "cs_log_bayes_factor":float(cols[hdi["cs_log_bayes_factor"]])
+                            "cs_log_bayes_factor":float(cols[hdi["cs_log_bayes_factor"]]) if cols[hdi["cs_lob_bayes_factor"]] != "NA" else float("nan")
 
                         }
                     )

--- a/pheweb/serve/data_access/db.py
+++ b/pheweb/serve/data_access/db.py
@@ -1883,7 +1883,7 @@ class AutoreportingDao(AutorepVariantDB):
                     record.update(
                         {
                             "locus_id":cols[hdi["locus_id"]],
-                            "phenocode":cols[hdi["phenotype"]],
+                            "phenocode":phenotype,
                             "good_cs":bool(cols[hdi["good_cs"]]),
                             "lead_mlogp":float(cols[hdi["lead_mlogp"]]),
                             "lead_beta":float(cols[hdi["lead_beta"]]),

--- a/pheweb/serve/data_access/db.py
+++ b/pheweb/serve/data_access/db.py
@@ -1916,7 +1916,7 @@ class AutoreportingDao(AutorepVariantDB):
                         all_traits_strict = cols[hdi["found_associations_strict"]]
                         all_traits_relaxed = cols[hdi["found_associations_relaxed"]]
                     record["all_traits_strict"] = all_traits_strict
-                    record["all_traits_relazed"] = all_traits_relaxed
+                    record["all_traits_relaxed"] = all_traits_relaxed
                     data.append(record)
             return data
         return []

--- a/pheweb/serve/data_access/db.py
+++ b/pheweb/serve/data_access/db.py
@@ -1890,7 +1890,7 @@ class AutoreportingDao(AutorepVariantDB):
                             "functional_variants_strict":cols[hdi["functional_variants_strict"]],
                             "credible_set_variants":cols[hdi["credible_set_variants"]],
                             "cs_size":int(cols[hdi["cs_size"]]),
-                            "cs_log_bayes_factor":float(cols[hdi["cs_log_bayes_factor"]]) if cols[hdi["cs_lob_bayes_factor"]] != "NA" else float("nan")
+                            "cs_log_bayes_factor":float(cols[hdi["cs_log_bayes_factor"]]) if cols[hdi["cs_log_bayes_factor"]] != "NA" else float("nan")
 
                         }
                     )

--- a/pheweb/serve/server_jeeves.py
+++ b/pheweb/serve/server_jeeves.py
@@ -477,7 +477,7 @@ class ServerJeeves(object):
         # fill in ukbb data
         var_strs = [a["locus_id"].replace("chr","").split("_") for a in data]
         variants = [Variant(v[0],v[1],v[2],v[3]) for v in var_strs]
-        ukbbvars: Dict[Variant,Dict[str,str]] = self.ukbb_dao.get_matching_results(phenocode, variants)
+        ukbbvars = self.ukbb_dao.get_matching_results(phenocode, variants)
         ukbb_vals = {}
         for var in ukbbvars.keys():
             ukbb_vals["chr{}_{}_{}_{}".format(var.chr,var.pos,var.ref,var.alt)] = {


### PR DESCRIPTION
This PR does the following:
- Removes need for ukbb api that autoreporting group report api call had. If the ukbb api is available, it will be used, but it won't anymore prevent getting results.
- Drops pandas from autoreporting group report functions. This makes the functions a bit more verbose, but also increases performance. On a local machine, difference was 10-50X (i.e. pandas was 10-50x slower (runtime 10-100ms -> 0.3-10ms), depending on input). With the data behind an NFS, I would guess this difference is smaller, but probably still substantial.