### PR TITLE
Refactor autoreporting get group variants

### DIFF
--- a/pheweb/serve/data_access/db.py
+++ b/pheweb/serve/data_access/db.py
@@ -1813,20 +1813,7 @@ class AutoreportingDao(AutorepVariantDB):
         try:
             conn = self.get_connection()
             with conn.cursor(pymysql.cursors.DictCursor) as cursori:
-                if self.release == 5:
-                    sql = (
-                        "SELECT * , "
-                        " chrom chr , "
-                        " null af_alt , "
-                        " null af_alt_cases , "
-                        " GENOME_FI_enrichment_nfe_est af_alt_controls , "
-                        " FG_INFO INFO , "
-                        " null enrichment_nfsee "
-                        "FROM autoreporting_variants "
-                        "WHERE rel=%s AND phenotype=%s AND locus_id=%s"
-                    )
-                else:
-                    sql = "SELECT * FROM autoreporting_variants WHERE rel=%s AND phenotype=%s AND locus_id=%s"
+                sql = "SELECT * FROM autoreporting_variants WHERE rel=%s AND phenotype=%s AND locus_id=%s"
                 cursori.execute(sql, ["r{}".format(self.release), phenotype, locus_id])
                 result = cursori.fetchall()
             return result

--- a/pheweb/serve/server_jeeves.py
+++ b/pheweb/serve/server_jeeves.py
@@ -540,26 +540,17 @@ class ServerJeeves(object):
         missing_columns = [a for a in required_columns if a not in data[0].keys()]
         missing_info = True if missing_columns == ["INFO"] else False
         if missing_columns not in [[],["INFO"]]:
-            msg = f"Error in server_jeeves.get_autoreport_variants: Missing columns {missing_columns}, when only INFO is allowed to be missing."
+            msg = f"Error in server_jeeves.get_autoreport_variants: Output of autoreporting_dao.get_group_variants is missing columns {missing_columns}, when only INFO is allowed to be missing. Check autoreporting db contents."
             print(msg)
             raise Exception(msg)
         #limit records to required columns
-        limited_data = []
-        for rec in data:
-            record = {}
-            for c in required_columns:
-                try:
-                    record[c] = rec[c]
-                except KeyError:
-                    if c == "INFO" and missing_info:
-                        record["INFO"] = "NA"
-                    else:
-                        raise
-            limited_data.append(record)
-        
+        limited_data = [
+            {c:record.get(c,"NA") for c in required_columns}
+            for record in data
+        ]
         #aggregate trait names by ;
         aggregated = {}
-        trait_merge_func = lambda a,b: ";".join(filter(lambda x: x != "NA" and x != "",[a,b]))
+        trait_merge_func = lambda a,b: ";".join( filter( lambda x: x != "NA" and x != "",set( (a,b) ) ) )
         for row in limited_data:
             if row["variant"] not in aggregated:
                 aggregated[row["variant"]] = row


### PR DESCRIPTION
This PR does the following changes to autoreporting get group variants functions:
- If all columns are present, do not call finngen annotation file api. This is a source of multiple seconds of latency in the current implementation, since there are usually a large amount of variants for which this is called. The annotation file is still used if INFO columns is missing from autoreporting db table.
- Drop pandas from the functions, since it really is not needed.
- Remove r5 autoreporting db compatibility shingles - If this causes problems, it's better to reimport the data to database correctly than have multiple compatibility hacks in the code (IMO).

Anticipated effects:
- In R11 and above, when looking at autoreporting groups, there should be a greatly diminished latency.