### PR TITLE
360 gene page does not change phenotype when clicking

### DIFF
--- a/ui/src/common/commonTableColumn.tsx
+++ b/ui/src/common/commonTableColumn.tsx
@@ -547,8 +547,7 @@ const phenotypeColumns = {
           const href = `/gene/${props.original.gene}/pheno/${props.original.phenocode || props.original.pheno}`
           const label = props.value === "NA" ? props.original.pheno : props.value
           return <a href={href}
-                    rel="noopener noreferrer"
-                    target="_blank">{label}</a>
+                    rel="noopener noreferrer">{label}</a>
         },
         minWidth: 300
       },

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -46,8 +46,8 @@ if (typeof (element) !== 'undefined' && element != null) {
             <Route path='/pheno/:pheno' component={Pheno} />
             <Route path='/region/:phenotype/:locus' component={Region} />
             <Route path='/about' component={About} />
-            <Route path='/gene/:gene' component={Gene} />
-            <Route path='/gene/:gene/pheno/:phenotype' component={Gene} />
+            <Route exact path='/gene/:gene' component={Gene} />
+            <Route exact path='/gene/:gene/pheno/:phenotype' component={Gene} />
             <Route path='/top_hits' component={TopHits} />
             <Route component={NotFoundEntity('page')} />
           </Switch>


### PR DESCRIPTION
Fixed gene paths in the react router. Additionally, as a small update modified opening of the /gene/:gene/pheno/:phenotype in the same page as gene instead of a separate window.