### PR TITLE
Fix merging columns in autoreporting backend

### DIFF
--- a/pheweb/serve/data_access/db.py
+++ b/pheweb/serve/data_access/db.py
@@ -1888,7 +1888,8 @@ class AutoreportingDao(AutorepVariantDB):
                     )
                     #join trait cols
                     if "specific_efo_trait_associations_relaxed" in hdr:
-                        merge_func = lambda a,b : ";".join(list(filter(lambda x:x!="NA",[a,b])))
+                        #filter out empty and missing entries
+                        merge_func = lambda a,b : ";".join(list(filter(lambda x:(x!="NA" and x != ""),[a,b])))
                         all_traits_strict = merge_func(
                             cols[hdi["specific_efo_trait_associations_strict"]],
                             cols[hdi["found_associations_strict"]]


### PR DESCRIPTION
Merging columns resulted in ";" when having no values. Fixed that so either empty strings "" or "NA" are filtered out, so columns are merged correctly.