### PR TITLE
fix parsing of strings representing numbers

### DIFF
--- a/ui/src/common/commonTableColumn.test.tsx
+++ b/ui/src/common/commonTableColumn.test.tsx
@@ -1,13 +1,53 @@
 /* eslint-env jest */
-import { pValueCellFormatter,
-         pValueSentinel,
-	 createHeader,
-	 addHeader,
-	 nearestGeneFormatter,
-	 createCSVLinkHeaders,
-	 filterDownload } from "./commonTableColumn";
+import {
+  pValueCellFormatter,
+  pValueSentinel,
+  createHeader,
+  addHeader,
+  nearestGeneFormatter,
+  createCSVLinkHeaders,
+  filterDownload, optionalCellScientificFormatter,
+  optionalCellNumberFormatter, optionalCellDecimalFormatter,
+} from './commonTableColumn';
 import {render, screen} from '@testing-library/react'
 import React from "react"
+
+test("optionalCellScientificFormatter handles empty string", () => {
+  const actual = optionalCellScientificFormatter({ value : "" })
+  const expected = ""
+  expect(actual).toBe(expected)
+});
+
+test("optionalCellScientificFormatter handles numbers", () => {
+  const actual = optionalCellScientificFormatter({ value : "1.0" })
+  const expected = "1.0e+0"
+  expect(actual).toBe(expected)
+});
+
+
+test("optionaCellNumberFormatter handles empty string", () => {
+  const actual = optionalCellNumberFormatter({ value : "" })
+  const expected = ""
+  expect(actual).toBe(expected)
+});
+
+test("optionalCellScientificFormatter handles numbers", () => {
+  const actual = optionalCellNumberFormatter({ value : "1.0" })
+  const expected = 1
+  expect(actual).toBe(expected)
+});
+
+test("optionalCellDecimalFormatter handles empty string", () => {
+  const actual = optionalCellDecimalFormatter({ value : "" })
+  const expected = ""
+  expect(actual).toBe(expected)
+});
+
+test("optionalCellDecimalFormatter handles numbers", () => {
+  const actual = optionalCellDecimalFormatter({ value : "1.0" })
+  const expected = "1.00"
+  expect(actual).toBe(expected)
+});
 
 test("null filterDownload", () => {
   const actual = filterDownload(null)

--- a/ui/src/common/commonTableColumn.tsx
+++ b/ui/src/common/commonTableColumn.tsx
@@ -5,6 +5,7 @@ import { variantFromStr, variantToPheweb, variantToStr } from "./commonModel";
 import { scientificFormatter, shortNumberFormatter } from "./commonFormatter";
 import { LabelKeyObject , Headers } from "react-csv/components/CommonPropTypes";
 import matchSorter from 'match-sorter';
+import { string } from 'purify-ts';
 
 interface PhewebWindow extends Window {
   release_prev: number;
@@ -33,20 +34,19 @@ const emsize = getSize();
 
 export const pValueSentinel = 5e-324;
 
-const textCellFormatter = (props : { value : any }) => props.value;
-
-const decimalCellFormatter = (props) => (+props.value).toPrecision(3);
-const optionalCellDecimalFormatter = (props) => isNaN(+props.value) ? props.value : decimalCellFormatter(props);
+const textCellFormatter : <X>( props : {value : X}) => X = (props) => props.value;
+const decimalCellFormatter : <X>( props : {value : X}) => string = (props) => (+props.value).toPrecision(3);
+export const optionalCellDecimalFormatter = (props) => isNaN(+props.value) || props.value === "" ? props.value : decimalCellFormatter(props);
 
 const tofixed = (v,n) => {
     return typeof(v) == typeof(0) ? v.toFixed(n) : v
 }
 
-const numberCellFormatter = (props) => +props.value;
-const optionaCellNumberFormatter = (props) => isNaN(+props.value) ? props.value : numberCellFormatter;
+const numberCellFormatter = (props) : number => +props.value;
+export const optionalCellNumberFormatter = (props) => isNaN(+props.value) || props.value === "" ? props.value : numberCellFormatter(props);
 
-const scientificCellFormatter = (props) => (+props.value).toExponential(1);
-const optionalCellScientificFormatter = (props) => isNaN(+props.value) ? props.value : scientificCellFormatter(props);
+const scientificCellFormatter = (props) : string => (+props.value).toExponential(1);
+export const optionalCellScientificFormatter = (props) => isNaN(+props.value) || props.value === "" ? props.value : scientificCellFormatter(props);
 
 export const nearestGeneFormatter = (geneName : string | null | undefined) => {
        const geneLabels = geneName?.split(",")?.map(geneName => <a href={`/gene/${geneName}`}>{geneName}</a>);
@@ -162,7 +162,7 @@ const formatters = {
   "optionalDecimal": decimalCellFormatter,
 
   "number": numberCellFormatter,
-  "optionalNumber": optionaCellNumberFormatter,
+  "optionalNumber": optionalCellNumberFormatter,
 
   "scientific": scientificCellFormatter,
   "optionalScientific": optionalCellScientificFormatter,


### PR DESCRIPTION
javascript treats empty spaces at zero for e.g. +"" == 0 string representations of numeric values should be checked for empty string.