### PR TITLE
add logging level to config

### DIFF
--- a/config/config.longformat.r11.py
+++ b/config/config.longformat.r11.py
@@ -7,6 +7,8 @@ data_dir="/mnt/nfs/pheweb/r11/release/"
 resource_dir="/mnt/nfs/pheweb/r11/release/resources"
 cache="/mnt/nfs/pheweb/r11/release/cache/"
 
+logging_level="WARNING"
+
 database_conf = (
     { "annotation": { "TabixAnnotationDao": { "matrix_path": "/mnt/nfs/pheweb/r11/dev/annotation/variants/R11_annotated_variants_v2.gz" ,
                                               "gene_column" : "gene_most_severe" } } },

--- a/pheweb/serve/server.py
+++ b/pheweb/serve/server.py
@@ -42,7 +42,15 @@ from .components.coding.service import coding
 from flask_cors import CORS
 
 import logging
-logging.basicConfig(level=logging.DEBUG)
+log_d = {
+    "NOTSET":logging.NOTSET,
+    "DEBUG":logging.DEBUG,
+    "INFO":logging.INFO,
+    "WARNING":logging.WARNING,
+    "ERROR":logging.ERROR,
+    "CRITICAL":logging.CRITICAL,
+}
+logging.basicConfig(level=log_d.get(conf.get("logging_level"),logging.WARNING))
 
 app = Flask(__name__,
             # this is hack so this it doesn't get confused on the static subdirectory


### PR DESCRIPTION
Noticed that logging costs us some money, so setting the logging level to a higher level in production would make sense.

Added logging level to config and then it's loaded in server.py. Added an indirection from a string to a constant from logging module since I don't want to import anything in config.py.