### PR TITLE
fix:variant page not loading for variants without rsid in annotation

### DIFF
--- a/ui/src/components/Variant/variantAPI.tsx
+++ b/ui/src/components/Variant/variantAPI.tsx
@@ -12,8 +12,10 @@ export const getVariant= (variant: Variant,
 }
 
 export  const getEnsembl = (rsid : String,
-                            sink: (s: Ensembl.Data) => void,getURL = get) : void => {
-  getURL(`https://grch37.rest.ensembl.org/variation/human/${rsid}?content-type=application/json`, sink)
+                            sink: (s: Ensembl.Data) => void,
+                            handler? :  Handler,
+                            getURL = get) : void => {
+  getURL(`https://grch37.rest.ensembl.org/variation/human/${rsid}?content-type=application/json`, sink, handler)
 }
 
 


### PR DESCRIPTION
fix: variant page not loading for variants without rsid in annotation #430

Problem

When the rsid is NA it fails to fetch ensembl.

Solution

Filter out rsids that do not start with rs* as they are mostly likely malformed.

Catch HTTP fetch errors and display them in the UI.

Fixes #430
Closes #430