### PR TITLE
440 sync gene aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ mkdir -p ${OUT_DIR}/generated-by-pheweb/sites
 mkdir -p ${OUT_DIR}/.pheweb/cache
 ```
 
-Copy unannotated variants sites file to be used by pheweb during the generation of new pheweb resources:
+Copy unannotated variants sites file to be used by pheweb which is required for generating new pheweb resources:
 ```
 gsutil cp gs://r10-data-green/regenie/demopheno/sites.tsv ${OUT_DIR}/generated-by-pheweb/sites/sites-unannotated.tsv
 ```
@@ -29,17 +29,17 @@ There are two ways to update the resources:
 
 **Option 1** If you would like to use pheweb-native genes pre-processing step which includes downloading gencode gene annotation file, selecting protein-coding/IG/TR genes, de-duplicating gene symbols and gene ids, run the following:
 ```
-# downloads fresh genes annotation gtf and formats genes file that will be used in other steps
+# download fresh genes annotation gtf and formats genes file
 pheweb download-genes
 
-# adds nearest_genes column to the variant sites by using genes file generated above
+# add nearest_genes column to the variant sites by using genes file generated above
 pheweb add-genes
 
-# creates genes aliases db using genes file
+# create genes aliases db using freshly created genes file
 pheweb make-gene-aliases-sqlite3
 ``` 
 
-**Option 2** If you would like to keep gene types other than protein-coding/IG/TR in the pheweb broser, perform steps described below:
+**Option 2** If you would like to keep gene types other than protein-coding/IG/TR in pheweb browser, perform steps described below:
 
 ```
 # Download gene annotation file and remove gene symbol duplicates
@@ -56,23 +56,23 @@ BEGIN{FS=OFS="\t"}
         }
 ' | awk '!seen[$4]++' > genes-b38-v39.bed
 
-# adds nearest_genes column to the variant sites by using genes file generated above
-pheweb add-genes --genes-filepath gencode.v39.genes.nodups.bed
+# add nearest_genes column to the variant sites by using genes file generated above
+pheweb add-genes --genes-filepath genes-b38-v39.bed
 
-# creates genes aliases db using genes file generated above
+# create genes aliases db using genes file generated above
 cp genes-b38-v39.bed ${OUT_DIR}/.pheweb/cache/
 pheweb make-gene-aliases-sqlite3
 
 ```
 
-Copy generated resources to be served by the pheweb browser to the cloud bucket:
+Copy generated resources to be served by the pheweb browser to google cloud storage bucket:
 ```
 ${OUT_DIR}/.pheweb/cache/genes-b38-v39.bed
 ${OUT_DIR}/generated-by-pheweb/resources/gene_aliases.sqlite3
 ${OUT_DIR}/generated-by-pheweb/sites/sites.tsv
 ```
 
-The Latest pheweb docker image can be used to run pheweb commands:
+The latest pheweb docker image can be used to run pheweb commands:
 ```
 docker run -it --rm \
 -v $PWD/${OUT_DIR}:/root \

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -25,15 +25,22 @@ RUN apt-get install cmake libcurl4-openssl-dev  --yes
 
 # install nodejs
 RUN apt-get install curl software-properties-common gnupg --yes
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -x -
-RUN apt-get install nodejs --yes
-
+RUN apt-get update; \
+    apt-get install -y ca-certificates curl gnupg; \
+    mkdir -p /etc/apt/keyrings; \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+     | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg; \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" \
+     > /etc/apt/sources.list.d/nodesource.list; \
+    apt-get -qy update; \
+    apt-get -qy install nodejs;
 
 RUN apt-get update && apt-get install --no-install-recommends texlive wget --yes
 # install cloudsql
 RUN wget --no-check-certificate https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 -O /usr/local/bin/cloud_sql_proxy && \
     chmod +x /usr/local/bin/cloud_sql_proxy
 
+RUN apt-get install bzip2 -y 
 RUN curl -LO https://github.com/samtools/htslib/releases/download/1.9/htslib-1.9.tar.bz2 && \
     tar -xvjf htslib-1.9.tar.bz2 && cd htslib-1.9 && \
     ./configure && make && make install && cd .. && rm -rf htslib-1.9*
@@ -58,8 +65,13 @@ RUN rm -r /pheweb
 ADD . /pheweb
 ADD pheweb/load/external_matrix.py /usr/local/bin/
 
+# install gsutil
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | \
+    tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
+    gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && apt-get update -y && apt-get install google-cloud-sdk -y
+
 # remove build tools
 RUN apt-get purge git gcc rustc cmake --yes
-
+    
 EXPOSE 8080
 CMD cloud_sql_proxy -instances=$CLOUD_SQL_PROXY_INSTANCES -credential_file=$CLOUD_SQL_PROXY_CREDENTIAL_FILE & cd $PHEWEB_DIR && pheweb serve --port 8080 --num-workers 1

--- a/pheweb/file_utils.py
+++ b/pheweb/file_utils.py
@@ -18,7 +18,6 @@ import pysam
 from .utils import PheWebError, get_phenolist, chrom_order
 from .conf_utils import conf, get_field_parser, validate_fields
 
-
 def get_generated_path(*path_parts):
     return os.path.join(conf.data_dir, "generated-by-pheweb", *path_parts)
 
@@ -34,7 +33,7 @@ genome_build = "38"
 if genome_build not in ["37", "38"]:
     raise ("genome build needs to be 37 or 38")
 dbsnp_version = "151"
-genes_version = "37"
+genes_version = "39"
 
 common_filepaths = {
     "phenolist": os.path.join(conf.data_dir, "pheno-list.json"),

--- a/pheweb/load/download_genes.py
+++ b/pheweb/load/download_genes.py
@@ -43,6 +43,8 @@ snRNA
 snoRNA
 TEC
 vaultRNA
+lncRNA
+vault_RNA
 '''.split()).union(good_genetypes)
 
 def get_all_genes(gencode_filepath):

--- a/pheweb/load/download_genes.py
+++ b/pheweb/load/download_genes.py
@@ -124,16 +124,11 @@ def run(argv):
         if not os.path.exists(gencode_filepath):
             make_basedir(gencode_filepath)
             if genome_build == '37':
-                wget.download(
-                    url="ftp://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_25/GRCh37_mapping/gencode.v25lift37.annotation.gtf.gz",
-                    out=gencode_filepath
-                )
+                url=f"ftp://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_{genes_version}/GRCh37_mapping/gencode.v{genes_version}lift37.annotation.gtf.gz",
             else:
-                wget.download(
-                    url="ftp://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_25/gencode.v25.annotation.gtf.gz",
-                    out=gencode_filepath
-                )
-            print('gencode annotations downloaded')
+                url=f"ftp://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_{genes_version}/gencode.v{genes_version}.annotation.gtf.gz"
+            wget.download( url=url, out=gencode_filepath)
+            print('gencode annotations downloaded from {} to {} - generating final file {}'.format(url, gencode_filepath, genes_filepath))
         genes = get_all_genes(gencode_filepath)
         genes = dedup_ensg(genes)
         genes = dedup_symbol(genes)

--- a/pheweb/load/make_gene_aliases_sqlite3.py
+++ b/pheweb/load/make_gene_aliases_sqlite3.py
@@ -97,8 +97,7 @@ def run(argv:List[str]) -> None:
         download_genes.run([])
     else:
         print("getting an existing bed file: {}".format(gene_filepath))
-        genes = [{'canonical': canonical, 'ensg':ensg} for _,_,_,canonical,ensg in get_gene_tuples_with_ensg()]
-        
+        genes = [{'canonical': canonical, 'ensg': ensg.split('.')[0]} for _,_,_,canonical,ensg in get_gene_tuples_with_ensg()]
         assert len({g['ensg'] for g in genes}) == len(genes), 'Detected duplicates in gene symbols in the provided genes file {}'.format(gene_filepath)
         assert len({g['canonical'] for g in genes}) == len(genes), 'Detected duplicates in ensembl gene ids in the provided genes file {}'.format(gene_filepath)
     

--- a/pheweb/load/make_gene_aliases_sqlite3.py
+++ b/pheweb/load/make_gene_aliases_sqlite3.py
@@ -98,11 +98,9 @@ def run(argv:List[str]) -> None:
     else:
         print("getting an existing bed file: {}".format(gene_filepath))
         genes = [{'canonical': canonical, 'ensg':ensg} for _,_,_,canonical,ensg in get_gene_tuples_with_ensg()]
-        if not len({g['ensg'] for g in genes}) == len(genes) or not len({g['canonical'] for g in genes}) == len(genes):
-            gene_filepath_new = "{}_not_valid.bed".format(gene_filepath)
-            print('Detected duplicates in the provided genes file - rename {} to {}. Downloading genes instead'.format(gene_filepath, gene_filepath_new))
-            os.rename(gene_filepath, gene_filepath_new)
-            download_genes.run([])
+        
+        assert len({g['ensg'] for g in genes}) == len(genes), 'Detected duplicates in gene symbols in the provided genes file {}'.format(gene_filepath)
+        assert len({g['canonical'] for g in genes}) == len(genes), 'Detected duplicates in ensembl gene ids in the provided genes file {}'.format(gene_filepath)
     
     dest_filepath = Path(get_filepath('gene-aliases-sqlite3', must_exist=False)())
     print('sqlite filename: {}'.format(dest_filepath))


### PR DESCRIPTION
- Added gsutil to docker image since import.wdl is using it to copy generated resources to the google cloud storage and in addittion updated deprecated installation method for npm 
- Updated annotation step in import workflow to use bed file, if specified, for creating all of pheweb resources related to gene annotation including gene aliases db. If genes file is not specified, download publicly available gencode annotation and use that instead.
- Updated gene version for downloading gencode gene annotation