### PR TITLE
fix: hover cluster plot on coding page

### DIFF
--- a/tests/pheweb/serve/components/coding/test_fs_storage.py
+++ b/tests/pheweb/serve/components/coding/test_fs_storage.py
@@ -1,0 +1,5 @@
+from pheweb.serve.components.coding.fs_storage import format_path, fetch_cluster_plot, FileCodingDAO
+
+def test_format_path() -> None:
+    assert format_path("","")("") == ""
+    assert format_path("/root/","{plot_root}{variant}.png")("variant") == "/root/variant.png"


### PR DESCRIPTION
provided a configuration setting for providing
a format string for the file path.