### PR TITLE
fix:selection on colocalization tables

### DIFF
--- a/ui/src/components/Region/Colocalization/ColocalizationList.tsx
+++ b/ui/src/components/Region/Colocalization/ColocalizationList.tsx
@@ -98,13 +98,11 @@ const ColocalizationList = (props : Props) => {
         setRowSelected(selectedRow ? undefined : key);
     }
 
-    const isSelected = (key : string) => {
-        return selectedRow === key;
-    }
+    const isSelected = (key : string) => selectedRow?.endsWith(key) || false;
 
     const rowFn = (state : {}, rowInfo : Row<Colocalization>, column : Column<Colocalization>, instance) => {
         return { onClick: (e : Event, handleOriginal : (undefined | (() => void))) => handleOriginal && handleOriginal() ,
-                 style: { background: (rowInfo && selectedRow && +selectedRow === rowInfo.original.colocalization_id)? "lightgrey" : undefined }
+                 style: { background: (rowInfo && selectedRow && selectedRow?.endsWith(rowInfo.original.colocalization_id))? "lightgrey" : undefined }
         };
     };
 

--- a/ui/src/components/Region/LocusZoom/RegionCustomLocuszooms.test.tsx
+++ b/ui/src/components/Region/LocusZoom/RegionCustomLocuszooms.test.tsx
@@ -2,6 +2,38 @@
 import React from "react"
 import { chunk, clinvarlESearchCollect, clinvarlESearchURL, empty } from './RegionCustomLocuszooms';
 
+import {clinvar_label, clinvar_significance, clinvar_trait} from "./RegionCustomLocuszooms";
+import {Clinvar} from "./RegionModel";
+
+test('clinvar_label', () => {
+	expect(clinvar_label('test',undefined)).toStrictEqual([])
+	expect(clinvar_label('test',null)).toStrictEqual([])
+	expect(clinvar_label('test','label')).toStrictEqual(['test label'])
+})
+
+test('clinvar_significance', () => {
+	expect(clinvar_significance({} as unknown as Clinvar.Data)).toStrictEqual("")
+	expect(clinvar_significance({ clinical_impact_classification : { description : "cic" }} as unknown as Clinvar.Data)).toStrictEqual("Clinical cic")
+	expect(clinvar_significance({ germline_classification : { description : "germ" }} as unknown as Clinvar.Data)).toStrictEqual("Germline germ")
+	expect(clinvar_significance({ oncogenicity_classification : { description : "oncogenicity" }} as unknown as Clinvar.Data)).toStrictEqual("Oncogenicity oncogenicity")
+	expect(clinvar_significance({
+		clinical_impact_classification : { description : "cic" },
+		germline_classification : { description : "germ" },
+		oncogenicity_classification : { description : "oncogenicity" }
+	} as unknown as Clinvar.Data)).toStrictEqual("Clinical cic , Germline germ , Oncogenicity oncogenicity")
+})
+
+test('clinvar_trait', () => {
+	expect(clinvar_trait({} as unknown as Clinvar.Data)).toStrictEqual("")
+	expect(clinvar_trait({ clinical_impact_classification : { trait_set : [ { trait_name : "clinical"}] } } as unknown as Clinvar.Data)).toStrictEqual("clinical")
+	expect(clinvar_trait({ germline_classification : { trait_set : [ { trait_name : "germline"}] } } as unknown as Clinvar.Data)).toStrictEqual("germline")
+	expect(clinvar_trait({ oncogenicity_classification : { trait_set : [ { trait_name : "oncogenicity"}] } } as unknown as Clinvar.Data)).toStrictEqual("oncogenicity")
+
+	expect(clinvar_trait({ clinical_impact_classification : { trait_set : [ { trait_name : "clinical"}] },
+		germline_classification : { trait_set : [ { trait_name : "germline"}] },
+		oncogenicity_classification : { trait_set : [ { trait_name : "oncogenicity"}] } } as unknown as Clinvar.Data)).toStrictEqual("germline clinical oncogenicity")
+})
+
 test("clinvarlESearchURL", () => {
 	const actual = "testURL/esummary.fcgi?db=clinvar&retmode=json&id=1,2,3,4"
 	const expected = clinvarlESearchURL("testURL/")(["1","2","3","4"])

--- a/ui/src/components/Region/LocusZoom/RegionModel.tsx
+++ b/ui/src/components/Region/LocusZoom/RegionModel.tsx
@@ -1,0 +1,87 @@
+export namespace Clinvar {
+
+export type Data = {
+    uid:                            string;
+    obj_type:                       string;
+    accession:                      string;
+    accession_version:              string;
+    title:                          string;
+    variation_set:                  VariationSet[];
+    supporting_submissions:         { [key: string]: string[] };
+    germline_classification?:        Classification;
+    clinical_impact_classification?: Classification;
+    oncogenicity_classification?:    Classification;
+    record_status:                  string;
+    gene_sort:                      string;
+    chr_sort:                       string;
+    location_sort:                  string;
+    variation_set_name:             string;
+    variation_set_id:               string;
+    genes:                          Gene[];
+    molecular_consequence_list:     string[];
+    protein_change:                 string;
+    fda_recognized_database:        string;
+}
+
+type Classification = {
+    description:    string;
+    last_evaluated: string;
+    review_status:  string;
+    trait_set:      TraitSet[];
+}
+
+type TraitSet = {
+    trait_xrefs: Xref[];
+    trait_name:  string;
+}
+
+type Xref = {
+    db_source: string;
+    db_id:     string;
+}
+
+type Gene = {
+    symbol: string;
+    geneid: string;
+    strand: string;
+    source: string;
+}
+
+type VariationSet = {
+    measure_id:      string;
+    variation_xrefs: Xref[];
+    variation_name:  string;
+    cdna_change:     string;
+    aliases:         any[];
+    variation_loc:   VariationLOC[];
+    allele_freq_set: AlleleFreqSet[];
+    variant_type:    string;
+    canonical_spdi:  string;
+}
+
+type AlleleFreqSet = {
+    source:       string;
+    value:        string;
+    minor_allele: string;
+}
+
+type VariationLOC = {
+    status:             string;
+    assembly_name:      string;
+    chr:                string;
+    band:               string;
+    start:              string;
+    stop:               string;
+    inner_start:        string;
+    inner_stop:         string;
+    outer_start:        string;
+    outer_stop:         string;
+    display_start:      string;
+    display_stop:       string;
+    assembly_acc_ver:   string;
+    annotation_release: string;
+    alt:                string;
+    ref:                string;
+}
+
+}


### PR DESCRIPTION
The select table IDs changed after upgrading the Reacttable library, and the logic to determine the currently selected row had to be updated.

The Clinvar response changed, and the code had to be updated to handle this.

closes #444 
