### PR TITLE
Import WDL: pheno task failing because of wrong relative folder

### DIFF
--- a/wdl/import.wdl
+++ b/wdl/import.wdl
@@ -276,6 +276,7 @@ task pheno {
         pheweb qq && \
         pheweb bgzip-phenos &&
         find ./
+        cd .. # move out from pheweb folder so relative paths work
 	# find just to make sure the whole sequence is completed
 	# and you know what you have.
 


### PR DESCRIPTION
In pheno task, the phenotype operations are done in pheweb folder. When redoing the import wdl to not rely on cromwell root data folder (since that is not guaranteed to stay the same, as shown when moving to gcp batch backend), I forgot to add in the extra cd out of the pheweb folder. This messed up file uploads in the task. 

This PR adds that one cd, which fixes the pheno task. I had already done that when debugging recessive imports, but the fix did not end up in the pheweb PR.