### PR TITLE
529-fix-manhattan-file-path

### DIFF
--- a/pheweb/load/annotate_manhattan.py
+++ b/pheweb/load/annotate_manhattan.py
@@ -145,7 +145,8 @@ def create_runner(annotation_filepath: str,
         nonlocal gnomad_filepath
         phenocode = pheno['phenocode']
         manhattan_filepath = common_filepaths['manhattan'](phenocode)
-        output_filepath = common_filepaths['compressed-manhattan'].format(manhattan_filepath)
+        compressed_filepath = common_filepaths['compressed-manhattan'].format(manhattan_filepath)
+        output_filepath = compressed_filepath if compress else manhattan_filepath
         arguments = Arguments(manhattan_filepath=manhattan_filepath,
                               gnomad_filepath=gnomad_filepath,
                               annotation_filepath=annotation_filepath,


### PR DESCRIPTION
Write to the Manhattan path if no compression is specified otherwise, write to the compressed path.

closes #529

┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=1482434913) by [Unito](https://www.unito.io)
