### PR TITLE
fix indexing None in getting variant page, fix some type signatures

### DIFF
--- a/pheweb/serve/data_access/db.py
+++ b/pheweb/serve/data_access/db.py
@@ -269,7 +269,7 @@ class AnnotationDB(object):
         return
 
     @abc.abstractmethod
-    def get_single_variant_annotations(self, variant: Variant, cpra) -> Variant:
+    def get_single_variant_annotations(self, variant: Variant, cpra) -> Optional[Variant]:
         """
         Retrieve variant annotations for a single variant. Returns a variant with annotations in id 'annot'  and including all old annotations
         """
@@ -372,7 +372,7 @@ class ResultDB(object):
 
     def get_single_variant_results(
         self, variant: Variant
-    ) -> Tuple[Variant, List[PhenoResult]]:
+    ) -> Optional[Tuple[Variant, List[PhenoResult]]]:
         """
         Returns all results and annotations for given variant. Returns tuple of Variant (including updated annotations if any) and phenotype results.
         Returns None if variant does not exist.
@@ -834,7 +834,7 @@ class TabixResultDao(ResultDB):
 
     def get_single_variant_results(
         self, variant: Variant
-    ) -> Tuple[Variant, PhenoResult]:
+    ) -> Optional[Tuple[Variant, List[PhenoResult]]]:
 
         res = self.get_variants_results([variant])
         for r in res:
@@ -1471,7 +1471,7 @@ class TabixAnnotationDao(AnnotationDB):
                 "No annotation datatype configuration found. Data will be stored as is."
             )
 
-    def get_single_variant_annotations(self, variant: Variant, cpra) -> Variant:
+    def get_single_variant_annotations(self, variant: Variant, cpra) -> Optional[Variant]:
         res = self.get_variant_annotations([variant], cpra)
         for r in res:
             if r == variant:

--- a/pheweb/serve/server_jeeves.py
+++ b/pheweb/serve/server_jeeves.py
@@ -306,17 +306,15 @@ class ServerJeeves(object):
         ## chaining variants like these retain all the existing annotations.
         r = self.result_dao.get_single_variant_results(variant)
 
-        # if matrix is of longformat append rest of the phenotypes for which summary stats were filtered
-        if self.result_dao.longformat:
-            r = self.result_dao.append_filt_phenos(r)
-
-        v_annot = self.annotation_dao.get_single_variant_annotations(r[0], self.conf.anno_cpra)
-
-        # add rsids from varaint annotation if wasn't available in the merged sumstat matrix
-        if self.result_dao.longformat and v_annot.rsids is None:
-            v_annot.add_annotation("rsids", v_annot.annotation['annot']['rsid'])
 
         if r is not None:
+            # if matrix is of longformat append rest of the phenotypes for which summary stats were filtered
+            if self.result_dao.longformat:
+                r = self.result_dao.append_filt_phenos(r)
+
+            v_annot = self.annotation_dao.get_single_variant_annotations(r[0], self.conf.anno_cpra)
+
+
             if v_annot is None:
                 ## no annotations found even results were found. Should not happen except if the results and annotation files are not in sync
                 print("Warning! Variant results for " + str(r[0]) + " found but no basic annotation!")
@@ -324,6 +322,10 @@ class ServerJeeves(object):
                 var.add_annotation("annot", {})
             else:
                 var = v_annot
+            # add rsids from variant annotation if wasn't available in the merged sumstat matrix
+            if self.result_dao.longformat and var.rsids is None:
+                var.add_annotation("rsids", var.annotation['annot']['rsid'])
+
             gnomad = self.gnomad_dao.get_variant_annotations([var])
             if len(gnomad) == 1:
                 var.add_annotation('gnomad', gnomad[0]['var_data'])


### PR DESCRIPTION
Fixes #557
Moves None check for variant results from resultDB before indexing into variant results.
Fixes some type annotations.
