### PR TITLE
minimize disks in import wdl

### DIFF
--- a/wdl/import.wdl
+++ b/wdl/import.wdl
@@ -68,7 +68,7 @@ task preprocess {
     	cpu: 2
         memory: "${mem} GB"
         bootDiskSizeGb: 30
-        disks: "local-disk 40 HDD"
+        disks: "local-disk 10 HDD"
         zones: "europe-west1-b"
         preemptible: 0
   }

--- a/wdl/import.wdl
+++ b/wdl/import.wdl
@@ -67,8 +67,8 @@ task preprocess {
         docker: "${docker}"
     	cpu: 2
         memory: "${mem} GB"
-        bootDiskSizeGb: 50
-        disks: "local-disk 200 HDD"
+        bootDiskSizeGb: 30
+        disks: "local-disk 40 HDD"
         zones: "europe-west1-b"
         preemptible: 0
   }
@@ -114,7 +114,7 @@ task sites {
         docker: "${docker}"
     	cpu: 2
     	memory: "2 GB"
-        bootDiskSizeGb: 50
+        bootDiskSizeGb: 30
         disks: "local-disk ${disk} HDD"
         zones: "europe-west1-b"
         preemptible: 0
@@ -309,8 +309,8 @@ task pheno {
         docker: "${docker}"
     	cpu: 2
     	memory: "10 GB"
-        bootDiskSizeGb: 50
-        disks: "local-disk 200 HDD"
+        bootDiskSizeGb: 30
+        disks: "local-disk 70 HDD"
         zones: "europe-west1-b"
         preemptible: 0
     }
@@ -659,8 +659,8 @@ task filter_sumstat {
         docker: "${docker}"
         memory: "2 GB"
         cpu: "1"
-        bootDiskSizeGb: 50
-        disks: "local-disk ${disk_size} SSD"
+        bootDiskSizeGb: 30
+        disks: "local-disk ${disk_size} HDD"
         zones: "europe-west1-b"
         preemptible: 0
     }
@@ -703,7 +703,7 @@ task get_phenolist {
         docker: "${docker}"
         memory: "8 GB"
         cpu: "2"
-        bootDiskSizeGb: 50
+        bootDiskSizeGb: 30
         zones: "europe-west1-b"
         disks: "local-disk ${disk} HDD"
         preemptible: 0


### PR DESCRIPTION
Make disks smaller so wdl does not throttle on disk quota
Not like we needed that much anyways
userresults import has been running apparently successfully 2-3 times for now with these mods