### PR TITLE
Simplify the QC variant imports issue#570

### DIFF
--- a/scripts/import_missing_qc_variants_files.py
+++ b/scripts/import_missing_qc_variants_files.py
@@ -39,13 +39,13 @@ def generate_resulted_row(output_header, row, xfile_header):
     
     for index,name in enumerate(xfile_header): 
         xfile_columns_index[name] = index
-    
+
     variant = row[xfile_columns_index['Variant']]
     splited_variant = variant.split(":")
     resulted_row.append(splited_variant[0].replace('chrX', 'chr23'))
     resulted_row.append(splited_variant[1])
 
-    for index,column_name in enumerate(output_header):
+    for index,column_name in enumerate(output_header.split("\t")):
         if column_name in COLUMNS_MAPPING_DICT:
             column_name_xfile = COLUMNS_MAPPING_DICT[column_name]
             resulted_row.append(row[xfile_columns_index[column_name_xfile]])
@@ -75,10 +75,10 @@ def main_script(input_path, output_path):
                     print('Loading data ...')
                     reader = csv.reader(infile, delimiter='\t')
                     header = next(reader)
-                    header_row = "chrom\t\pos\t" + "\t".join(header)
+                    header_row = "chrom\tpos\t" + "\t".join(header)
                     if is_header_written is False:
                         output_header = header_row
-                        out_file.write(header_row)
+                        out_file.write(header_row +'\n')
                         is_header_written = True
                     for row in reader:
                         # autosomal file

--- a/scripts/import_missing_qc_variants_files.py
+++ b/scripts/import_missing_qc_variants_files.py
@@ -14,6 +14,7 @@ def get_files_list(input_path, output_path):
 COLUMNS_MAPPING_DICT = {
     "Variant": "Variant",
     "callRate": "variant_qc.call_rate",
+    "AC": "variant_qc.AC",
     "AF": "variant_qc.AF",
     "nCalled": "variant_qc.n_called",
     "nNotCalled": "variant_qc.n_not_called",
@@ -36,6 +37,7 @@ def generate_resulted_row(output_header, row, xfile_header):
     """
     resulted_row = []
     xfile_columns_index = {}
+    splited_output_header = output_header.split("\t")
     
     for index,name in enumerate(xfile_header): 
         xfile_columns_index[name] = index
@@ -45,10 +47,11 @@ def generate_resulted_row(output_header, row, xfile_header):
     resulted_row.append(splited_variant[0])
     resulted_row.append(splited_variant[1])
 
-    for index,column_name in enumerate(output_header.split("\t")):
+    # skip #chrom and pos from output_header
+    for index,column_name in enumerate(splited_output_header[2:]):
         if column_name in COLUMNS_MAPPING_DICT:
             column_name_xfile = COLUMNS_MAPPING_DICT[column_name]
-            if column_name == 'Variant':
+            if 'Variant' in column_name:
                 resulted_row.append(variant)
             else:
                 resulted_row.append(row[xfile_columns_index[column_name_xfile]])

--- a/scripts/import_missing_qc_variants_files.py
+++ b/scripts/import_missing_qc_variants_files.py
@@ -40,15 +40,18 @@ def generate_resulted_row(output_header, row, xfile_header):
     for index,name in enumerate(xfile_header): 
         xfile_columns_index[name] = index
 
-    variant = row[xfile_columns_index['Variant']]
+    variant = row[xfile_columns_index['Variant']].replace('chr', '').replace('X', '23')
     splited_variant = variant.split(":")
-    resulted_row.append(splited_variant[0].replace('chrX', 'chr23'))
+    resulted_row.append(splited_variant[0])
     resulted_row.append(splited_variant[1])
 
     for index,column_name in enumerate(output_header.split("\t")):
         if column_name in COLUMNS_MAPPING_DICT:
             column_name_xfile = COLUMNS_MAPPING_DICT[column_name]
-            resulted_row.append(row[xfile_columns_index[column_name_xfile]])
+            if column_name == 'Variant':
+                resulted_row.append(variant)
+            else:
+                resulted_row.append(row[xfile_columns_index[column_name_xfile]])
         else:
             resulted_row.append('NA')
 
@@ -83,9 +86,11 @@ def main_script(input_path, output_path):
                     for row in reader:
                         # autosomal file
                         if len(row) == 24:
-                            splited_variant = row[0].split(":")
+                            variant = row[0].replace('chr', '')
+                            splited_variant = variant.split(":")
                             row.insert(0, splited_variant[0])
                             row.insert(1, splited_variant[1])
+                            row[2] = variant
                             line = f"\t".join(row)+"\n"
                             out_file.write(line)
                         # Xfile check

--- a/scripts/import_missing_qc_variants_files.py
+++ b/scripts/import_missing_qc_variants_files.py
@@ -42,7 +42,7 @@ def generate_resulted_row(output_header, row, xfile_header):
     
     variant = row[xfile_columns_index['Variant']]
     splited_variant = variant.split(":")
-    resulted_row.append(splited_variant[0].replace('chr', ''))
+    resulted_row.append(splited_variant[0].replace('chrX', 'chr23'))
     resulted_row.append(splited_variant[1])
 
     for index,column_name in enumerate(output_header):

--- a/scripts/import_missing_qc_variants_files.py
+++ b/scripts/import_missing_qc_variants_files.py
@@ -1,5 +1,6 @@
 import os, sys
 import csv
+import argparse
 
 def get_files_list(input_path, output_path):
     files = []
@@ -90,10 +91,17 @@ def main_script(input_path, output_path):
             print(f"An error occurred: {e}")
 
 # check the argument 
-if len(sys.argv) == 3:
-    INPUT_FOLDER_PATH = sys.argv[1]
-    if f"/{sys.argv[2]}".endswith('.tsv'):
-        OUTPUT_FOLDER_PATH = INPUT_FOLDER_PATH + f"/{sys.argv[2]}"
+parser = argparse.ArgumentParser(description="The QC variant import script!")
+
+parser.add_argument('input_file_path', type=str, default='/mnt/disks/data/data-directory/path/to/qc_variant_folder')
+parser.add_argument('output_file_name', type=str, default='combined_sorted_output_file.tsv')
+
+args = parser.parse_args()
+
+if args.input_file_path and args.output_file_name:
+    INPUT_FOLDER_PATH = args.input_file_path
+    if f"/{args.output_file_name}".endswith('.tsv'):
+        OUTPUT_FOLDER_PATH = INPUT_FOLDER_PATH + f"/{args.output_file_name}"
         main_script(INPUT_FOLDER_PATH, OUTPUT_FOLDER_PATH)
     else:
         print("Sorry, output file name should be tsv. e-g string.tsv")

--- a/scripts/import_missing_qc_variants_files.py
+++ b/scripts/import_missing_qc_variants_files.py
@@ -75,7 +75,7 @@ def main_script(input_path, output_path):
                     print('Loading data ...')
                     reader = csv.reader(infile, delimiter='\t')
                     header = next(reader)
-                    header_row = "chrom\tpos\t" + "\t".join(header)
+                    header_row = "#chrom\tpos\t" + "\t".join(header)
                     if is_header_written is False:
                         output_header = header_row
                         out_file.write(header_row +'\n')

--- a/scripts/import_missing_qc_variants_files.py
+++ b/scripts/import_missing_qc_variants_files.py
@@ -10,28 +10,25 @@ def get_files_list(input_path, output_path):
             files.append(file_path)
     return files
 
-# mapping the from chrom xfile => autosomal
+# mapping the columns name from chrom xfile => autosomal
 COLUMNS_MAPPING_DICT = {
-    "Variant" : "Variant",
-    "variant_qc.call_rate": "callRate",
-    "variant_qc.AF": "AF",
-    "variant_qc.n_called": "nCalled",
-    "variant_qc.n_not_called": "nNotCalled",
-    "variant_qc.n_het": "nHet",
-    "variant_qc.dp_stats.mean":'dpMean',
-    "variant_qc.dp_stats.stdev": 'dpStDev',
-    "variant_qc.gq_stats.mean": 'gqMean',
-    "variant_qc.gq_stats.stdev": 'gqStDev',
-    "variant_qc.n_non_ref": 'nNonRef',
-    "variant_qc.p_value_hwe": 'pHWE',
-    "filters": "FILTERS",
-    "info.QD": "QD",
+    "Variant": "Variant",
+    "callRate": "variant_qc.call_rate",
+    "AF": "variant_qc.AF",
+    "nCalled": "variant_qc.n_called",
+    "nNotCalled": "variant_qc.n_not_called",
+    "nHet": "variant_qc.n_het",
+    "dpMean": "variant_qc.dp_stats.mean",
+    "dpStDev": "variant_qc.dp_stats.stdev",
+    "gqMean": "variant_qc.gq_stats.mean",
+    "gqStDev": "variant_qc.gq_stats.stdev",
+    "nNonRef": "variant_qc.n_non_ref",
+    "pHWE": "variant_qc.p_value_hwe",
+    "FILTERS": "filters",
+    "QD": "info.QD",
     "IS_LCR": "IS_LCR",
     "failed_filter": "failed_filter"
 }
-
-#inverting the column mapping dict
-INVERTED_COLUMN_MAPPING = {v: k for k, v in COLUMNS_MAPPING_DICT.items()}
 
 def generate_resulted_row(output_header, row, xfile_header):
     """
@@ -49,8 +46,8 @@ def generate_resulted_row(output_header, row, xfile_header):
     resulted_row.append(splited_variant[1])
 
     for index,column_name in enumerate(output_header):
-        if column_name in INVERTED_COLUMN_MAPPING:
-            column_name_xfile = INVERTED_COLUMN_MAPPING[column_name]
+        if column_name in COLUMNS_MAPPING_DICT:
+            column_name_xfile = COLUMNS_MAPPING_DICT[column_name]
             resulted_row.append(row[xfile_columns_index[column_name_xfile]])
         else:
             resulted_row.append('NA')


### PR DESCRIPTION
https://github.com/FINNGEN/pheweb/blob/master/scripts/import_missing_qc_variants_files.py

Here are some improvement areas:

Using argparse instead of sys.argv so you get help and argument descriptions
Currently, the variant columns is assumed to be the first column, and the script will break if the variant column is anywhere else in the file. Instead, make it so that column order does not affect the script's working.
There's some logic errors and unnecessary lines, such as https://github.com/FINNGEN/pheweb/blob/master/scripts/import_missing_qc_variants_files.py#L28, which will always be None, meaning the checks on lines 37 and 43 for and output_file_header is None is always true, therefore unnecessary.
The handling of the chromosome X now depends on both the column order of the autosomal files AND the column order of the chromosome X file. What I think would be better is to have a mapping from the column names from the autosomal files to the column names to the chromosome X file, and use that to map the values to the correct positions for the chromosome X file.