### PR TITLE
Update dockerfile to work with changes from #564

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,5 +1,5 @@
 FROM docker:20.10.12
-FROM debian:10
+FROM debian:12-slim
 
 # can change this in k8s deployment yaml to serve from another directory
 ENV PHEWEB_DIR /mnt/nfs/pheweb
@@ -19,8 +19,7 @@ ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 
 RUN apt-get update --allow-releaseinfo-change
-RUN apt-get install make gcc libz-dev libbz2-dev liblzma-dev zlib1g-dev --yes
-RUN apt-get install cmake libcurl4-openssl-dev  --yes
+RUN apt-get install make gcc libz-dev libbz2-dev liblzma-dev zlib1g-dev  cmake libcurl4-openssl-dev  --yes
 
 # install nodejs
 RUN apt-get install curl software-properties-common gnupg --yes
@@ -34,43 +33,44 @@ RUN apt-get update; \
     apt-get -qy update; \
     apt-get -qy install nodejs;
 
-RUN apt-get update && apt-get install --no-install-recommends texlive wget --yes
+RUN apt-get update && apt-get install --no-install-recommends texlive wget bzip2 --yes
 # install cloudsql
 RUN wget --no-check-certificate https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64 -O /usr/local/bin/cloud_sql_proxy && \
     chmod +x /usr/local/bin/cloud_sql_proxy
 
-RUN apt-get install bzip2 -y
 RUN curl -LO https://github.com/samtools/htslib/releases/download/1.9/htslib-1.9.tar.bz2 && \
     tar -xvjf htslib-1.9.tar.bz2 && cd htslib-1.9 && \
     ./configure && make && make install && cd .. && rm -rf htslib-1.9*
-
-
-ADD . /pheweb
-
-# install python packages and perquisites
-RUN apt-get update && apt-get install default-libmysqlclient-dev git python3-pip libffi-dev libz-dev  libbz2-dev liblzma-dev libssl-dev --yes --fix-missing
-RUN python3 -m pip install cython
-RUN apt-get install rustc --yes
-RUN python3 -m pip install pip==20.1.1 --upgrade
-RUN python3 -m pip install /pheweb
-RUN python3 -m pip freeze
-
-# create react js bundle
-RUN cd /pheweb/ui && npm config set fetch-retries 10 && npm install
-RUN cd /pheweb/ui && npm run build
-RUN cp -R /pheweb/pheweb/serve/static/* /usr/local/lib/python3.7/dist-packages/pheweb/serve/static/
-RUN rm -r /pheweb
-
-ADD . /pheweb
-ADD pheweb/load/external_matrix.py /usr/local/bin/
 
 # install gsutil
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | \
     tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
     gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && apt-get update -y && apt-get install google-cloud-sdk -y
 
+# install python packages and perquisites
+RUN apt-get update && apt-get install default-libmysqlclient-dev git python3-pip python3-venv libffi-dev libz-dev  libbz2-dev liblzma-dev libssl-dev rustc --yes --fix-missing
+RUN apt-get install --reinstall pkg-config cmake-data --yes --fix-missing
+
+RUN python3 -m venv /opt/env
+RUN /opt/env/bin/pip install cython
+RUN /opt/env/bin/pip install --upgrade pip
+ADD . /pheweb
+RUN /opt/env/bin/pip install /pheweb
+RUN /opt/env/bin/pip freeze
+
+# create react js bundle
+RUN cd /pheweb/ui && npm config set fetch-retries 10 && npm install
+RUN cd /pheweb/ui && npm run build
+RUN cp -R /pheweb/pheweb/serve/static/* /opt/env/lib/python3.11/site-packages/pheweb/serve/static/
+RUN rm -r /pheweb
+
+ADD . /pheweb
+ADD pheweb/load/external_matrix.py /opt/env/bin/
+
 # remove build tools
 RUN apt-get purge git gcc rustc cmake --yes
-
+RUN apt-get autoremove --yes
+# important: add virtual environment to path
+ENV PATH="/opt/env/bin:$PATH"
 EXPOSE 8080
 CMD cloud_sql_proxy -instances=$CLOUD_SQL_PROXY_INSTANCES -credential_file=$CLOUD_SQL_PROXY_CREDENTIAL_FILE & cd $PHEWEB_DIR && pheweb serve --port 8080 --num-workers 1


### PR DESCRIPTION
Changes:
- Update to debian 12 slim from debian 10
- Change to use virtual env, since debian 12 manages its python env with apt, making installing packages unqieldy for the whole image
- Reorder some commands for better cacheability (all installs before adding pheweb folder)

This is a REQUIRED PR before merging #564 , since it breaks the dockerfile due to updated packages.