### PR TITLE
fix missing maf_control field, it was due to trailing newline in last…

### DIFF
--- a/pheweb/serve/data_access/db.py
+++ b/pheweb/serve/data_access/db.py
@@ -843,18 +843,18 @@ class TabixResultCommonDao:
             )
             return []
 
-        ind = [i for i,e in enumerate(header) if 'chr' in e][0]
+        chr_idx = [i for i,e in enumerate(header) if 'chr' in e][0]
         result = {}
         for variant_row in tabix_iter:
             split = variant_row.split("\t")
             chrom = (
-                split[ind]
+                split[chr_idx]
                 .replace("chr", "")
                 .replace("X", "23")
                 .replace("Y", "24")
                 .replace("MT", "25")
             )
-            v = Variant(chrom, split[ind+1], split[ind+2], split[ind+3])
+            v = Variant(chrom, split[chr_idx+1], split[chr_idx+2], split[chr_idx+3])
             for pheno in phenos:
                 # get the common variant columns
                 phenotype, beta, sebeta, maf, maf_case, maf_control, mlogp, pval = self.get_variant_common_columns(
@@ -873,7 +873,6 @@ class TabixResultCommonDao:
                         result[v].append(pr)
                     else:
                         result[v] = [pr]
-
         return result.items()
 
 class TabixResultDao(ResultDB):
@@ -1005,7 +1004,7 @@ class TabixResultFiltDao(ResultDB):
     def __init__(self, phenos, matrix_path, columns):
         self.matrix_path = matrix_path
         self.columns = columns
-        self.header = gzip.open(self.matrix_path,'rt').readline().split("\t")
+        self.header = gzip.open(self.matrix_path,'rt').readline().strip("\n").split("\t")
         self.pheno_map = phenos(0)
         self.tabix_result_common_dao = TabixResultCommonDao(self.pheno_map)
 

--- a/tests/pheweb/serve/data_access/db_test.py
+++ b/tests/pheweb/serve/data_access/db_test.py
@@ -83,7 +83,7 @@ class TestTabixResultDao(unittest.TestCase):
         with open(test_pheno_list_path, "r") as f:
             self.pheno_list_data = json.load(f)
         self.mocked_pheno_list_data=lambda x:self.pheno_list_data[0]
-        self.split_query = re.split("-|:|/|_", test_variant)
+        self.split_query = test_variant.split(":")
         self.variant = Variant(
             self.split_query[0],
             self.split_query[1],
@@ -130,13 +130,22 @@ class TestTabixResultFiltDao(unittest.TestCase):
         with open(test_pheno_list_path, "r") as f:
             self.pheno_list_data = json.load(f)
         self.mocked_pheno_list_data=lambda x:self.pheno_list_data[0]
-        self.split_query = re.split("-|:|/|_", test_variant)
+        self.split_query = test_variant.split(":")
         self.variant = Variant(
             self.split_query[0],
             self.split_query[1],
             self.split_query[2],
             self.split_query[3],
         )
+        self.validation_value = {
+            "beta":2.05148,
+            "sebeta":1.02193,
+            "maf":0.00598008,
+            "maf_case":0.00992459,
+            "maf_control":0.00597798,
+            "mlogp":1.34969,
+            "pval":0.04470025493374374
+        }
 
     def test_should_return_get_single_variant_results(self):
         # check get_single_variant_results
@@ -166,6 +175,14 @@ class TestTabixResultFiltDao(unittest.TestCase):
         self.assertEqual(
             variant_results[0]["n_control"], phenolist_values[0]["num_controls"]
         )
+        self.assertEqual(variant_results[0]["phenocode"],"AB1_ASPERGILLOSIS")
+        self.assertEqual(variant_results[0]["pval"],self.validation_value["pval"])
+        self.assertEqual(variant_results[0]["beta"],self.validation_value["beta"])
+        self.assertEqual(variant_results[0]["sebeta"],self.validation_value["sebeta"])
+        self.assertEqual(variant_results[0]["maf"],self.validation_value["maf"])
+        self.assertEqual(variant_results[0]["maf_case"],self.validation_value["maf_case"])
+        self.assertEqual(variant_results[0]["maf_control"],self.validation_value["maf_control"])
+        self.assertEqual(variant_results[0]["mlogp"],self.validation_value["mlogp"])
 
 
 class TestTabixResultCommonDao(unittest.TestCase):
@@ -181,7 +198,7 @@ class TestTabixResultCommonDao(unittest.TestCase):
         self.split = self.data[1].split("\t")
         self.phenos=["AB1_ASPERGILLOSIS"]
 
-        self.split_query = re.split("-|:|/|_", test_variant)
+        self.split_query = test_variant.split(":")
 
         self.validation_value = {
             "beta":"2.05148",


### PR DESCRIPTION
Fixes #590, or at least fixes yet another reason for that error. 
There was a trailing newline in last header column when initializing TabixResultFiltDAO, which is why maf_control field was missing only when using that. This PR fixes that and extends current test to catch similar errors in future.