### PR TITLE
Fix MissingVariantDao missing variants

### DIFF
--- a/pheweb/serve/data_access/db.py
+++ b/pheweb/serve/data_access/db.py
@@ -638,8 +638,6 @@ class MissingVariantDao(MissingVariantDB):
             if columns[self.header_index["Variant"]] == variant.varid:
                 json_obj = dict(zip(self.colnames, columns))
                 return json_obj
-            else:
-                pass
         return None
 
 


### PR DESCRIPTION
Error:  https://r13.finngen.fi/api/variant/9:128522658:A:G returns 404
Reason: MissingVariantDao only considered the first row in tabix iterator, which in this case led it to not consider the correct variant (which was second in the iterator).

This PR fixes the bug, and removes some checks in the function that seem to do nothing.