### PR TITLE
Restore the ability to return additional columns from the tabix dao

### DIFF
--- a/pheweb/serve/data_access/db.py
+++ b/pheweb/serve/data_access/db.py
@@ -735,146 +735,6 @@ def extend_pheno_result(pr : PhenoResult,
             setattr(pr, key, row[record_offset+offset])
     return pr
 
-class TabixResultCommonDao:
-    def __init__(self, pheno_map):
-        self.pheno_map = pheno_map
-
-    def get_variant_columns_using_header(self, values:list[str], header:list[str],columns:dict[str,str]):
-        hdi = {a:i for i,a in enumerate(header)}
-        phenotype = values[hdi[columns['pheno']]]
-        beta = values[hdi[columns['beta']]]
-        sebeta = values[hdi[columns['sebeta']]] if columns["sebeta"] in hdi else None
-        maf = values[hdi[columns['maf']]] if columns["maf"] in hdi else None
-        maf_case = values[hdi[columns['maf_cases']]] if columns["maf_cases"] in hdi else None
-        maf_control = values[hdi[columns['maf_controls']]] if columns["maf_controls"] in hdi else None
-        mlogp = values[hdi[columns['mlogp']]] if columns["mlogp"] in hdi else None
-        pval = values[hdi[columns['pval']]] if "pval" in hdi else None
-        return phenotype, beta, sebeta, maf, maf_case, maf_control, mlogp, pval
-
-    def get_variant_columns_using_header_offset(self, split, pheno, header_offset, columns):
-        phenotype = pheno[0] if pheno[0] else split[header_offset[columns["pheno"]]]
-        beta = split[pheno[1] + header_offset[columns["beta"]]]
-        sebeta = (
-            split[pheno[1] + header_offset[columns["sebeta"]]]
-            if "sebeta" in columns
-            else None
-        )
-        maf = (
-            split[pheno[1] + header_offset[columns["maf"]]]
-            if "maf" in columns and columns["maf"] in header_offset
-            else None
-        )
-        maf_case = (
-            split[pheno[1] + header_offset[columns["maf_cases"]]]
-            if "maf_cases" in columns and columns["maf_cases"] in header_offset
-            else None
-        )
-        maf_control = (
-            split[pheno[1] + header_offset[columns["maf_controls"]]]
-            if "maf_controls" in columns and columns["maf_controls"] in header_offset
-            else None
-        )
-        mlogp = (
-            split[pheno[1] + header_offset[columns["mlogp"]]]
-            if "mlogp" in columns
-            else None
-        )
-        pval = (
-            split[pheno[1] + header_offset[columns["pval"]]]
-            if "pval" in columns
-            else None
-        )
-        return phenotype, beta, sebeta, maf, maf_case, maf_control, mlogp, pval
-
-    def get_variant_common_columns(self, split, pheno, header_offset, columns, header):
-        """Return the list of common columns phenotype, beta, sebeta, maf, maf_case, maf_control, mlogp, pval
-        """
-        if header_offset is None:
-            return self.get_variant_columns_using_header(split, header,columns)
-        else:
-            return self.get_variant_columns_using_header_offset(split, pheno, header_offset, columns)
-
-    def get_common_pheno_results(self, phenotype, pval, beta, sebeta, maf, maf_case, maf_control, mlogp):
-        """Return the list of PhenoResult
-        """
-        pr = PhenoResult(
-            phenotype,
-            self.pheno_map[phenotype]["phenostring"]
-            if phenotype in self.pheno_map and "phenostring" in self.pheno_map[phenotype]
-            else None,
-            self.pheno_map[phenotype]["category"]
-            if phenotype in self.pheno_map and "category" in self.pheno_map[phenotype]
-            else None,
-            self.pheno_map[phenotype]["category_index"]
-            if phenotype in self.pheno_map and "category_index" in self.pheno_map[phenotype]
-            else None,
-            pval,
-            beta,
-            sebeta,
-            maf,
-            maf_case,
-            maf_control,
-            (
-                self.pheno_map[phenotype]["num_cases"]
-                 if phenotype in self.pheno_map and "num_cases" in self.pheno_map[phenotype]
-                else 0
-            ),
-            (
-                self.pheno_map[phenotype]["num_controls"]
-                if phenotype in self.pheno_map and "num_controls" in self.pheno_map[phenotype]
-                else 0
-            ),
-            mlogp,
-            (
-                self.pheno_map[phenotype]["num_samples"]
-                if phenotype in self.pheno_map and "num_samples" in self.pheno_map[phenotype]
-                else "NA"
-            ),
-        )
-        return pr
-
-    def get_common_variant_results_range(self, chrom, start, end, matrix_path, header, columns, header_offset, phenos):
-        chrom = "23" if chrom == "X" else chrom
-        try:
-            tabix_iter = pysam.TabixFile(matrix_path, parser=None).fetch(
-                chrom, start - 1, end)
-        except ValueError:
-            print(
-                "No variants in the given range. {}:{}-{}".format(chrom, start - 1, end)
-            )
-            return []
-
-        chr_idx = [i for i,e in enumerate(header) if 'chr' in e][0]
-        result = {}
-        for variant_row in tabix_iter:
-            split = variant_row.split("\t")
-            chrom = (
-                split[chr_idx]
-                .replace("chr", "")
-                .replace("X", "23")
-                .replace("Y", "24")
-                .replace("MT", "25")
-            )
-            v = Variant(chrom, split[chr_idx+1], split[chr_idx+2], split[chr_idx+3])
-            for pheno in phenos:
-                # get the common variant columns
-                phenotype, beta, sebeta, maf, maf_case, maf_control, mlogp, pval = self.get_variant_common_columns(
-                    split, pheno, header_offset, columns, header
-                )
-                if mlogp is not None and mlogp is not "" and mlogp != "NA":
-                    if pval is None:
-                        pval = str(math.pow(10, -1 * float(mlogp)))
-                if pval is not None and not pval == "" and not pval == "NA":
-                    pr = self.get_common_pheno_results(
-                        phenotype, pval, beta, sebeta, maf, maf_case, maf_control, mlogp
-                    )
-                    if header_offset is not None:
-                        pr = extend_pheno_result(pr,pheno[1],header_offset,split)
-                    if v in result:
-                        result[v].append(pr)
-                    else:
-                        result[v] = [pr]
-        return result.items()
 
 class TabixResultDao(ResultDB):
     def __init__(self, phenos, matrix_path, columns):
@@ -882,7 +742,7 @@ class TabixResultDao(ResultDB):
         self.matrix_path = matrix_path
         self.pheno_map = phenos(0)
         self.columns = columns
-        self.header = gzip.open(self.matrix_path,'rt').readline().split("\t")
+        self.header = gzip.open(self.matrix_path, "rt").readline().split("\t")
         self.phenos = [
             (h.split("@")[1], p_col_idx)
             for p_col_idx, h in enumerate(self.header)
@@ -899,13 +759,104 @@ class TabixResultDao(ResultDB):
                 i = i + 1
             p = s[1] if len(s) > 1 else None
 
-        self.tabix_result_common_dao = TabixResultCommonDao(self.pheno_map)
+        self.longformat = False
 
     def get_variant_results_range(self, chrom, start, end):
-        variant_results = self.tabix_result_common_dao.get_common_variant_results_range(
-            chrom, start, end, self.matrix_path, self.header, self.columns, self.header_offset, self.phenos
-        )
-        return variant_results
+
+        chrom = "23" if chrom == "X" else chrom
+        try:
+            tabix_iter = pysam.TabixFile(self.matrix_path, parser=None).fetch(
+                chrom, start - 1, end)
+        except ValueError:
+            print(
+                "No variants in the given range. {}:{}-{}".format(chrom, start - 1, end)
+            )
+            return []
+
+        ind = [i for i, e in enumerate(self.header) if "chr" in e][0]
+        result = {}
+        for variant_row in tabix_iter:
+            split = variant_row.split("\t")
+            chrom = (
+                split[ind]
+                .replace("chr", "")
+                .replace("X", "23")
+                .replace("Y", "24")
+                .replace("MT", "25")
+            )
+            v = Variant(chrom, split[ind + 1], split[ind + 2], split[ind + 3])
+            for pheno in self.phenos:
+                phenotype = (
+                    pheno[0]
+                    if pheno[0]
+                    else split[self.header_offset[self.columns["pheno"]]]
+                )
+                beta = split[pheno[1] + self.header_offset[self.columns["beta"]]]
+                sebeta = (
+                    split[pheno[1] + self.header_offset[self.columns["sebeta"]]]
+                    if "sebeta" in self.columns
+                    else None
+                )
+                maf = (
+                    split[pheno[1] + self.header_offset[self.columns["maf"]]]
+                    if "maf" in self.columns
+                    else None
+                )
+                maf_case = (
+                    split[pheno[1] + self.header_offset[self.columns["maf_cases"]]]
+                    if "maf_cases" in self.columns
+                    else None
+                )
+                maf_control = (
+                    split[pheno[1] + self.header_offset[self.columns["maf_controls"]]]
+                    if "maf_controls" in self.columns
+                    else None
+                )
+                mlogp = (
+                    split[pheno[1] + self.header_offset[self.columns["mlogp"]]]
+                    if "mlogp" in self.columns
+                    else None
+                )
+                pval = (
+                    split[pheno[1] + self.header_offset[self.columns["pval"]]]
+                    if "pval" in self.columns
+                    else None
+                )
+                if mlogp is not None and mlogp != "" and mlogp != "NA":
+                    if pval is None:
+                        pval = str(math.pow(10, -1 * float(mlogp)))
+                if pval is not None and pval != "" and pval != "NA":
+                    pr = PhenoResult(
+                        phenotype,
+                        self.pheno_map[phenotype]["phenostring"],
+                        self.pheno_map[phenotype]["category"],
+                        self.pheno_map[phenotype]["category_index"]
+                        if "category_index" in self.pheno_map[phenotype]
+                        else None,
+                        pval,
+                        beta,
+                        sebeta,
+                        maf,
+                        maf_case,
+                        maf_control,
+                        self.pheno_map[phenotype]["num_cases"]
+                        if "num_cases" in self.pheno_map[phenotype]
+                        else 0,
+                        self.pheno_map[phenotype]["num_controls"]
+                        if "num_controls" in self.pheno_map[phenotype]
+                        else 0,
+                        mlogp,
+                        self.pheno_map[phenotype]["num_samples"]
+                        if "num_samples" in self.pheno_map[phenotype]
+                        else "NA",
+                    )
+                    pr = extend_pheno_result(pr, pheno[1], self.header_offset, split)
+                    if v in result:
+                        result[v].append(pr)
+                    else:
+                        result[v] = [pr]
+
+        return result.items()
 
     def get_single_variant_results(
         self, variant: Variant
@@ -930,9 +881,8 @@ class TabixResultDao(ResultDB):
                     results.append(r)
         return results
 
-    def get_top_per_pheno_variant(self, chrom, start, end):
-        """Return the common pheno top per pheno variant
-        """
+    def get_top_per_pheno_variant_results_range(self, chrom, start, end):
+
         chrom = "23" if chrom == "X" else chrom
         try:
             tabix_iter = pysam.TabixFile(self.matrix_path, parser=None).fetch(
@@ -947,44 +897,98 @@ class TabixResultDao(ResultDB):
         top = defaultdict(lambda: defaultdict(dict))
 
         n_vars = 0
-        ind = [i for i,e in enumerate(self.header) if 'chr' in e][0]
+        ind = [i for i, e in enumerate(self.header) if "chr" in e][0]
         for variant_row in tabix_iter:
             n_vars = n_vars + 1
             split = variant_row.split("\t")
             for pheno in self.phenos:
-                # get the common variant columns
-                phenotype, beta, sebeta, maf, maf_case, maf_control, mlogp, pval = self.tabix_result_common_dao.get_variant_common_columns(
-                    split, pheno, self.header_offset, self.columns, self.header
+                phenotype = (
+                    pheno[0]
+                    if pheno[0]
+                    else split[self.header_offset[self.columns["pheno"]]]
+                )
+                beta = split[pheno[1] + self.header_offset[self.columns["beta"]]]
+                sebeta = (
+                    split[pheno[1] + self.header_offset[self.columns["sebeta"]]]
+                    if "sebeta" in self.columns
+                    else None
+                )
+                maf = (
+                    split[pheno[1] + self.header_offset[self.columns["maf"]]]
+                    if "maf" in self.columns
+                    else None
+                )
+                maf_case = (
+                    split[pheno[1] + self.header_offset[self.columns["maf_cases"]]]
+                    if "maf_cases" in self.columns
+                    else None
+                )
+                maf_control = (
+                    split[pheno[1] + self.header_offset[self.columns["maf_controls"]]]
+                    if "maf_controls" in self.columns
+                    else None
+                )
+                mlogp = (
+                    split[pheno[1] + self.header_offset[self.columns["mlogp"]]]
+                    if "mlogp" in self.columns
+                    else None
+                )
+                pval = (
+                    split[pheno[1] + self.header_offset[self.columns["pval"]]]
+                    if "pval" in self.columns
+                    else None
                 )
                 # Pick the smaller of values.  First try using mlog which
                 # maybe absent in earlier releases.  In this case fall back
                 # to using pval to order.
-                if mlogp is not None and mlogp is not "" and mlogp != "NA":
+                if mlogp is not None and mlogp != "" and mlogp != "NA":
                     if pval is None:
                         pval = str(math.pow(10, -1 * float(mlogp)))
                     # have mlogp compare mlog
                     is_less_than = (
-                        phenotype not in top or (float(mlogp)) > top[phenotype][1].mlogp
+                        phenotype not in top
+                        or (float(mlogp)) > top[phenotype][1].mlogp
                     )
                 else:
                     # we don't have mlogp use pval
                     is_less_than = (
-                        pval is not ""
+                        pval != ""
                         and pval != "NA"
                         and (
-                            phenotype not in top or (float(pval)) < top[phenotype][1].pval
+                            phenotype not in top
+                            or (float(pval)) < top[phenotype][1].pval
                         )
                     )
                 if is_less_than:
-                    pr = self.get_common_pheno_results(
-                        phenotype, pval, beta, sebeta, maf, maf_case, maf_control, mlogp
+                    pr = PhenoResult(
+                        phenotype,
+                        self.pheno_map[phenotype]["phenostring"],
+                        self.pheno_map[phenotype]["category"],
+                        self.pheno_map[phenotype]["category_index"]
+                        if "category_index" in self.pheno_map[phenotype]
+                        else None,
+                        pval,
+                        beta,
+                        sebeta,
+                        maf,
+                        maf_case,
+                        maf_control,
+                        self.pheno_map[phenotype]["num_cases"]
+                        if "num_cases" in self.pheno_map[phenotype]
+                        else 0,
+                        self.pheno_map[phenotype]["num_controls"]
+                        if "num_controls" in self.pheno_map[phenotype]
+                        else 0,
+                        mlogp,
+                        self.pheno_map[phenotype]["num_samples"]
+                        if "num_samples" in self.pheno_map[phenotype]
+                        else "NA",
                     )
-                    v = Variant(chrom, split[ind+1], split[ind+2], split[ind+3])
+                    v = Variant(chrom, split[ind + 1], split[ind + 2], split[ind + 3])
                     top[phenotype] = (v, pr)
 
         print(str(n_vars) + " variants iterated")
-
-        pheno_results = [
+        top = [
             PhenoResults(pheno=self.pheno_map[pheno], assoc=dat, variant=v)
             for pheno, (v, dat) in top.items()
         ]
@@ -992,163 +996,62 @@ class TabixResultDao(ResultDB):
         # A hack to handle missing mlogp
         # as sort is stable it should return
         # with the the pval order.
-        pheno_results.sort(key=lambda pheno: pheno.assoc.pval)
-        pheno_results.sort(key=lambda pheno: pheno.assoc.mlogp, reverse=True)
+        top.sort(key=lambda pheno: pheno.assoc.pval)
+        top.sort(key=lambda pheno: pheno.assoc.mlogp, reverse=True)
 
-        return pheno_results
-
-    def get_top_per_pheno_variant_results_range(self, chrom, start, end):
-        pheno_results = self.get_top_per_pheno_variant(chrom, start, end)
-        return pheno_results
-
-class TabixResultFiltDao(ResultDB):
-    def __init__(self, phenos, matrix_path, columns):
-        self.matrix_path = matrix_path
-        self.columns = columns
-        self.header = gzip.open(self.matrix_path,'rt').readline().strip("\n").split("\t")
-        self.header_offset = {item.split('\n')[0]: i for i, item in enumerate(self.header)}
-        self.pheno_map = phenos(0)
-        self.tabix_result_common_dao = TabixResultCommonDao(self.pheno_map)
-
-    def get_variant_results_range(self, chrom, start, end):
-        variant_results = self.tabix_result_common_dao.get_common_variant_results_range(
-            chrom, start, end, self.matrix_path, self.header, self.columns,self.header_offset, [(None, 0)]
-        )
-        return variant_results
-
-    def get_single_variant_results(
-        self, variant: Variant
-    ) -> Optional[Tuple[Variant, List[PhenoResult]]]:
-        """
-        Returns all results and annotations for given variant.
-        """
-        res = self.get_variants_results([variant])
-        for r in res:
-            if r[0] == variant:
-                # if matrix is of longformat append rest of the phenotypes for which summary stats were filtered
-                r = self.append_filt_phenos(r)
-                return r
-        return None
-
-    def get_variants_results(
-        self, variants: List[Variant]
-    ) -> List[Tuple[Variant, PhenoResult]]:
-        if type(variants) is not list:
-            variants = [variants]
-        results = []
-        for v in variants:
-            res = self.get_variant_results_range(v.chr, v.pos, v.pos)
-            for r in res:
-                if r[0] == v:
-                    results.append(r)
-        return results
+        return top
 
     def append_filt_phenos(
-        self, variant_phenoresult: Tuple[Variant, PhenoResult]
+        self, varaint_phenores: Tuple[Variant, PhenoResult]
     ) -> Tuple[Variant, PhenoResult]:
-        '''For a single variant append phenotypes filtered in longformat matrix.
-           Populates missing summary stats with none'''
+        """For a single variant append phenotypes filtered in longformat matrix.
+           Populates missing summary stats with none"""
 
-        phenolist = variant_phenoresult[1]
+        phenolist = varaint_phenores[1]
         var_phenocodes = [r.phenocode for r in phenolist]
 
         for phenotype in self.pheno_map:
             if phenotype not in var_phenocodes:
-                pr = self.tabix_result_common_dao.get_common_pheno_results(phenotype, 'NA', None, None, None, None, None, 'NA')
+                pr = PhenoResult(
+                    phenotype,
+                    self.pheno_map[phenotype]["phenostring"],
+                    self.pheno_map[phenotype]["category"],
+                    self.pheno_map[phenotype]["category_index"]
+                    if "category_index" in self.pheno_map[phenotype]
+                    else None,
+                    "NA",  # pval
+                    None,  # beta
+                    None,  # sebeta
+                    None,  # maf
+                    None,  # maf_case
+                    None,  # maf_control
+                    self.pheno_map[phenotype]["num_cases"]
+                    if "num_cases" in self.pheno_map[phenotype]
+                    else 0,
+                    self.pheno_map[phenotype]["num_controls"]
+                    if "num_controls" in self.pheno_map[phenotype]
+                    else 0,
+                    "NA",  # mlogp
+                    self.pheno_map[phenotype]["num_samples"]
+                    if "num_samples" in self.pheno_map[phenotype]
+                    else "NA",
+                )
                 phenolist.append(pr)
 
-        return (variant_phenoresult[0], phenolist)
+        return (varaint_phenores[0], phenolist)
 
 
-    def get_top_per_pheno_variant_results_range(
-        self, chrom, start, end
-    ) -> List[PhenoResults]:
-        """Retrieves top variant for each phenotype in a given range
-        Returns: A list of PhenoResults "pheno" which contains a phenotype dict, and "assoc" containing PhenoResult object, 'variant' contains Variant object. The list is sorted by p-value.
-        """
-
-        chrom = "23" if chrom == "X" else chrom
-        try:
-            tabix_iter = pysam.TabixFile(self.matrix_path,parser=None).fetch(
-                chrom, start - 1, end)
-        except:
-            print(
-                "No variants in the given range. {}:{}-{}".format(chrom, start - 1, end)
-            )
-        hdi = {a:i for i,a in enumerate(self.header)}
-        result_dict = {}
-        for variant_row in tabix_iter:
-            cols = variant_row.split("\t")
-            phenotype = cols[hdi["#pheno"]]
-            mlogp = cols[hdi["mlogp"]] if "mlogp" in hdi else None
-            pval = cols[hdi["pval"]] if "pval" in hdi else None
-            beta = cols[hdi["beta"]] if "beta" in hdi else None
-            sebeta = cols[hdi["sebeta"]] if "sebeta" in hdi else None
-            maf = cols[hdi["af_alt"]] if "af_alt" in hdi else None
-            maf_cases = cols[hdi["af_alt_cases"]] if "af_alt_cases" in hdi else None
-            maf_controls = cols[hdi["af_alt_controls"]] if "af_alt_controls" in hdi else None 
-            if mlogp is not None and mlogp is not "" and mlogp != "NA":
-                if pval is None:
-                    pval = str(math.pow(10, -1 * float(mlogp)))
-            else:
-                #convert pval to mlogp
-                try:
-                    mlogp = str(-math.log10(float(pval)))
-                except:
-                    continue
-            pr = PhenoResult(
-                phenotype,
-                self.pheno_map[phenotype]["phenostring"],
-                self.pheno_map[phenotype]["category"],
-                self.pheno_map[phenotype]["category_index"]
-                if "category_index" in self.pheno_map[phenotype]
-                else None,
-                pval,
-                beta,
-                sebeta,
-                maf,
-                maf_cases,
-                maf_controls,
-                self.pheno_map[phenotype]["num_cases"]
-                if "num_cases" in self.pheno_map[phenotype]
-                else 0,
-                self.pheno_map[phenotype]["num_controls"]
-                if "num_controls" in self.pheno_map[phenotype]
-                else 0,
-                mlogp,
-                self.pheno_map[phenotype]["num_samples"]
-                if "num_samples" in self.pheno_map[phenotype]
-                else "NA",
-            )
-            v = Variant(chrom,cols[hdi["pos"]],cols[hdi["ref"]],cols[hdi["alt"]])
-            #determine whether to save this in the result dict
-            if phenotype in result_dict:
-                #use mlogp
-                #all mlogps and pvals are guaranteed to be available, since values with neither are filtered out,
-                #and mlogp is calculated from pval and pval calculated from mlogp if one was missing
-                if not (mlogp is None or mlogp =="" or mlogp == "NA"):
-                    if float(mlogp) > result_dict[phenotype][1].mlogp:
-                        result_dict[phenotype] = (v,pr)
-                #pval
-                elif not (pval is None or pval =="" or pval =="NA"):
-                    if float(pval) < result_dict[phenotype][1].pval:
-                        result_dict[phenotype] = (v,pr)
-                #else: we can't compare, so nothing to do
-            else:
-                result_dict[phenotype] = (v,pr)
-            
-
-
-        #now we have data for each pheno in the data, then just order
-        pheno_results = [
-            PhenoResults(pheno=self.pheno_map[pheno], assoc=dat, variant=v)
-            for pheno, (v, dat) in result_dict.items()
-        ]
-
-        pheno_results.sort(key=lambda pheno: pheno.assoc.pval)
-        pheno_results.sort(key=lambda pheno: pheno.assoc.mlogp, reverse=True)
-
-        return pheno_results
+class TabixResultFiltDao(TabixResultDao):
+    def __init__(self, phenos, matrix_path, columns):
+        self.matrix_path = matrix_path
+        self.columns = columns
+        self.header = gzip.open(self.matrix_path, "rt").readline().split("\t")
+        self.header_offset = {
+            item.split("\n")[0]: i for i, item in enumerate(self.header)
+        }
+        self.phenos = [(None, 0)]
+        self.pheno_map = phenos(0)
+        self.longformat = True
 
 
 class ExternalMatrixResultDao(ExternalResultDB):

--- a/tests/pheweb/serve/data_access/db_test.py
+++ b/tests/pheweb/serve/data_access/db_test.py
@@ -7,7 +7,6 @@ from pheweb.serve.data_access.db import (
     optional_float,
     TabixResultDao,
     TabixResultFiltDao,
-    TabixResultCommonDao,
 )
 import unittest
 
@@ -16,6 +15,7 @@ test_wide_data_file_path = os.getcwd() + "/tests/mocked-data/mocked-wide.tsv.gz"
 test_pheno_list_path = os.getcwd() + "/tests/mocked-data/mocked-pheno-list.json"
 test_mocked_columns = {
     "pheno": "#pheno",
+    "pval": "pval",
     "mlogp": "mlogp",
     "beta": "beta",
     "sebeta": "sebeta",
@@ -184,106 +184,6 @@ class TestTabixResultFiltDao(unittest.TestCase):
         self.assertEqual(variant_results[0]["maf_control"],self.validation_value["maf_control"])
         self.assertEqual(variant_results[0]["mlogp"],self.validation_value["mlogp"])
 
-
-class TestTabixResultCommonDao(unittest.TestCase):
-    def setUp(self):
-        # Load resources
-        with gzip.open(test_data_file_path, "rt",encoding="utf-8") as f:
-            self.data = f.read().splitlines()
-        self.header = self.data[0].split("\t")
-        with open(test_pheno_list_path, "r") as f:
-            mocked_pheno_list_data = json.load(f)
-        self.mocked_pheno_list_data=lambda x:mocked_pheno_list_data[0]
-
-        self.split = self.data[1].split("\t")
-        self.phenos=["AB1_ASPERGILLOSIS"]
-
-        self.split_query = test_variant.split(":")
-
-        self.validation_value = {
-            "beta":"2.05148",
-            "sebeta":"1.02193",
-            "maf":"0.00598008",
-            "maf_case":"0.00992459",
-            "maf_control":"0.00597798",
-            "mlogp":"1.34969",
-            "pval":None
-        }
-
-    def test_should_return_variant_common_columns(self):
-        # check get_variant_common_columns
-        tabix_result_common = TabixResultCommonDao(self.mocked_pheno_list_data(0))
-        phenotype, beta, sebeta, maf, maf_case, maf_control, mlogp, pval = (
-            tabix_result_common.get_variant_common_columns(
-                self.split, self.phenos, None, test_mocked_columns, self.header
-            )
-        )
-        
-        self.assertEqual(phenotype, self.split[0])
-        self.assertEqual(beta, self.validation_value["beta"])
-        self.assertEqual(sebeta, self.validation_value["sebeta"])
-        self.assertEqual(maf, self.validation_value["maf"])
-        self.assertEqual(maf_case, self.validation_value["maf_case"])
-        self.assertEqual(maf_control, self.validation_value["maf_control"])
-        self.assertEqual(mlogp, self.validation_value["mlogp"])
-        self.assertEqual(pval, self.validation_value["pval"])
-
-    def test_should_return_variant_columns_using_header(self):
-        # check get_variant_columns_using_header
-        tabix_result_common = TabixResultCommonDao(self.mocked_pheno_list_data(0))
-        results = tabix_result_common.get_variant_columns_using_header(
-            self.split, self.header,test_mocked_columns
-        )
-        self.assertEqual(len(results), 8)
-
-    def test_should_return_common_pheno_results(self):
-        # check get_common_pheno_results
-        tabix_result_common = TabixResultCommonDao(self.mocked_pheno_list_data(0))
-        phenotype, beta, sebeta, maf, maf_case, maf_control, mlogp, pval = (
-            tabix_result_common.get_variant_columns_using_header(
-                self.split, self.header,test_mocked_columns
-            )
-        )
-        self.assertEqual(phenotype, self.split[0])
-        self.assertEqual(beta, self.validation_value["beta"])
-        self.assertEqual(sebeta, self.validation_value["sebeta"])
-        self.assertEqual(maf, self.validation_value["maf"])
-        self.assertEqual(maf_case, self.validation_value["maf_case"])
-        self.assertEqual(maf_control, self.validation_value["maf_control"])
-        self.assertEqual(mlogp, self.validation_value["mlogp"])
-        self.assertEqual(pval, self.validation_value["pval"])
-        # check common phenoresults
-        common_phenoresults = tabix_result_common.get_common_pheno_results(
-            phenotype, pval, beta, sebeta, maf, maf_case, maf_control, mlogp
-        )
-        self.assertIsNotNone(common_phenoresults)
-        self.assertEqual(common_phenoresults.beta, float(self.validation_value["beta"]))
-        self.assertEqual(common_phenoresults.sebeta, float(self.validation_value["sebeta"]) )
-        self.assertEqual(common_phenoresults.maf, float(self.validation_value["maf"]))
-        self.assertEqual(common_phenoresults.maf_case, float(self.validation_value["maf_case"]))
-        self.assertEqual(
-            common_phenoresults.maf_control, float(self.validation_value["maf_control"])
-        )
-        self.assertEqual(common_phenoresults.mlogp, float(self.validation_value["mlogp"]))
-        self.assertEqual(common_phenoresults.pval, self.validation_value["pval"])
-
-    def test_should_return_common_variant_results_range(self):
-        # check get_common_variant_results_range
-        tabix_result_common = TabixResultCommonDao(self.mocked_pheno_list_data(0))
-        variant_results_range = list(tabix_result_common.get_common_variant_results_range(
-            self.split_query[0],
-            int(self.split_query[1]),
-            int(self.split_query[1]),
-            test_data_file_path,
-            self.header,
-            test_mocked_columns,
-            None,
-            self.phenos,
-        ))
-        
-        self.assertIsNotNone(variant_results_range)
-        self.assertEqual(Variant(*self.split_query),variant_results_range[0][0])
-        #TODO: test that Phenoresult results are coherent
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
After attempting a refactor, I am going with the minimal fix on this one.
I am unsure why the original omission of self.header_offset was done.