### PR TITLE
update intervaltree to 3.2.1

### DIFF
--- a/pheweb/load/add_genes.py
+++ b/pheweb/load/add_genes.py
@@ -72,7 +72,7 @@ class GeneAnnotator(object):
         if chrom == 'MT': chrom = 'M'
         if chrom not in self._its:
             return ''
-        overlapping_genes = self._its[chrom].search(pos)
+        overlapping_genes = self._its[chrom].at(pos)
         if overlapping_genes:
             return ','.join(sorted(boltons.iterutils.unique_iter(og.data for og in overlapping_genes)))
         nearest_gene_end = self._gene_ends[chrom].get_item_before(pos)

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         'rauth~=0.7',
         'pysam~=0.23.0',
         'marisa-trie~=1.2.1',
-        'intervaltree==2.1.0',
+        'intervaltree==3.2.1',
         'tqdm~=4.67.0',
         'openpyxl~=3.1.5',
         'scipy~=1.15.2',


### PR DESCRIPTION
Fixes #610 
updates intervaltree package and replaces uses of deprecated search function with at function

Tested import of results, seems to work.