### PR TITLE
fix HLA config mistake

### DIFF
--- a/ui/src/components/HLA/HLA.tsx
+++ b/ui/src/components/HLA/HLA.tsx
@@ -10,7 +10,7 @@ import ReactTooltip from "react-tooltip";
 import HLATable from "./HLATable";
 
 declare let window: ConfigurationWindow;
-const config: { [key: string]: any } = window?.config?.userInterface?.coding?.config || defaultConfig;
+const config: { [key: string]: any } = window?.config?.userInterface?.hla?.config || defaultConfig;
 
 const HLA = (props) => {
 

--- a/ui/src/components/HLA/HLAModel.tsx
+++ b/ui/src/components/HLA/HLAModel.tsx
@@ -20,7 +20,9 @@ export namespace HLAModel {
 
 export default HLAModel;
 
-export interface HLAConfiguration {}
+export interface HLAConfiguration {
+  config? : { [key: string]: any };
+}
 
 export namespace AutoCompleteModel {
     type PhenotypeSearchResultRow = {


### PR DESCRIPTION
HLA was using coding config, causing the HLA page to get title and help text from Coding config when both tabs are defined.