### PR TITLE
Fix manhattan double tooltip

### DIFF
--- a/ui/src/components/Phenotype/phenotypeGWASD3.tsx
+++ b/ui/src/components/Phenotype/phenotypeGWASD3.tsx
@@ -220,7 +220,7 @@ const createGWASPlot = (phenotypeCode : string,
         const data = d.target.__data__ ;
         return mustacheText(template, reshape(data));
       })
-      .offset([-6, 0])
+      .offset([-2, 0])
 
     GWASSVG.call(pointTooltip);
 
@@ -264,7 +264,6 @@ const createGWASPlot = (phenotypeCode : string,
       .enter()
       .append('a')
       .attr('class', 'variant_point')
-      .attr('xlink:href', getLinkToLZ)
       .append('circle')
       .attr('id', function (d) {
         return `variant-point-${d.chrom}-${d.pos}-${d.ref}-${d.alt}`;
@@ -276,16 +275,10 @@ const createGWASPlot = (phenotypeCode : string,
         return y_scale(d.pScaled)
       })
       .attr('r', 2.3)
+      .attr('pointer-events', 'none') // let the hover ring capture mouse events, not the point itself
       .style('fill', function (d) {
         return color_by_chrom(d.chrom) as unknown as string; // TODO
       })
-      .on('mouseover', function (d) {
-        if (d.isDisabled !== true) {
-          //Note: once a tooltip has been explicitly placed once, it must be explicitly placed forever after.
-          pointTooltip.show(d, this)
-        }
-      })
-      .on('mouseout', pointTooltip.hide)
 
     // https://stackoverflow.com/questions/38233003/d3-js-v4-how-to-access-parent-groups-datum-index
     var bins = GWASPlot.append('g')


### PR DESCRIPTION
Previously there were two hover areas for each variant tooltip, in the variant dot itself and the hover ring around it. This causes a small visual bug were the same tooltip is shown two times, moving slightly when you move the cursor between the dot and the area surrounding it.

I removed the tooltip (and link) from the variant dot and made it ignore pointer events, so that the tooltip and the link are always in the larger hover circle around the variant dot. 