### PR TITLE
Few changes to fix logout issues

### DIFF
--- a/pheweb/serve/server.py
+++ b/pheweb/serve/server.py
@@ -1,15 +1,14 @@
-from ..utils import get_phenolist, get_use_phenocode_pheno_map, get_gene_tuples, pad_gene
+from ..utils import get_phenolist, get_use_phenocode_pheno_map, pad_gene
 from ..conf_utils import conf
 from ..file_utils import common_filepaths
 from .server_utils import get_pheno_region
 from .auth import GoogleSignIn
-from ..version import version as pheweb_version
 from typing import Optional
 from flask import Blueprint
 from ..text_utils import text_to_boolean
 from .data_access.db import Variant
 
-from flask import Flask, jsonify, render_template, request, redirect, abort, flash, current_app, send_from_directory, send_file, session, url_for,make_response
+from flask import Flask, jsonify, render_template, request, redirect, abort, flash, send_from_directory, session, url_for,make_response
 from flask_compress import Compress
 from flask_login import LoginManager, UserMixin, login_user, logout_user, current_user
 from prometheus_flask_exporter import PrometheusMetrics
@@ -20,23 +19,19 @@ import ipaddress
 import urllib
 import urllib.parse as urlparse
 from urllib.parse import urlencode
-import functools
 import importlib
 import re
 import math
 import traceback
-import json
 import os.path
-from .data_access import DataFactory
 from concurrent.futures import ThreadPoolExecutor
 
 from .server_jeeves  import ServerJeeves
 
-from collections import defaultdict
 from .encoder import FGJSONEncoder
 from .group_based_auth  import verify_membership
 
-from .server_auth import before_request, is_public, do_check_auth
+from .server_auth import is_public, do_check_auth
 
 from pheweb.serve.components.colocalization.view import colocalization
 from .components.chip.service import chip

--- a/pheweb/serve/server_auth.py
+++ b/pheweb/serve/server_auth.py
@@ -1,9 +1,7 @@
-from flask_login import LoginManager, UserMixin, login_user, logout_user, current_user
-from flask import Flask, jsonify, render_template, request, redirect, abort, flash, send_from_directory, send_file, session, url_for,make_response
+from flask_login import current_user
+from flask import jsonify, request, redirect, session, url_for, g
 from ..conf_utils import conf
-import functools
-from .group_based_auth  import verify_membership
-from flask import g
+from .group_based_auth import verify_membership
 
 def _is_api_request() -> bool:
     """Return True for fetch/XHR API calls that cannot follow OAuth redirects."""

--- a/pheweb/serve/server_auth.py
+++ b/pheweb/serve/server_auth.py
@@ -5,20 +5,29 @@ import functools
 from .group_based_auth  import verify_membership
 from flask import g
 
+def _is_api_request() -> bool:
+    """Return True for fetch/XHR API calls that cannot follow OAuth redirects."""
+    return request.path.startswith('/api/')
+
+
 def before_request():
-    
+
     if not conf.authentication:
         print('anonymous visited {!r}'.format(request.path))
         return None
     elif getattr(g, 'is_test', None) == True:
         return None
     elif current_user is None or not hasattr(current_user, 'email'):
+        if _is_api_request():
+            return jsonify({'status': 'error', 'message': 'not authenticated'}), 401
         return redirect(url_for('get_authorized',
                                 _scheme='https',
                                 _external=True))
     elif not verify_membership(current_user.email):
         print('{} is unauthorized and visited {!r}'.format(current_user.email, request.path))
         session['original_destination'] = request.path
+        if _is_api_request():
+            return jsonify({'status': 'error', 'message': 'not authorized'}), 403
         return redirect(url_for('get_authorized',
                                 _scheme='https',
                                 _external=True))

--- a/ui/src/components/Nav/Logout.tsx
+++ b/ui/src/components/Nav/Logout.tsx
@@ -13,8 +13,11 @@ const Logout = () => {
         getAuthentication(setCurrentUser)
     },[]);
 
-    const logoutHandler = (l : LogoutMessage) => { window.location.replace(logout_url.toString()) }
-    const clickHandler = () => doLogout(logoutHandler)
+    const logoutHandler = (_l : LogoutMessage) => { window.location.replace(logout_url.toString()) }
+    const clickHandler = (e : React.MouseEvent<HTMLAnchorElement>) => {
+        e.preventDefault()
+        doLogout(logoutHandler)
+    }
 
     const result = (currentUser === undefined)?
         <></>:


### PR DESCRIPTION
While investigating the logout issues on new R14/Results setup, I found these two issues in the login flow:

- API endpoints redirected to google SSO, even though they should just return 401/403. SSO login redirect is shown on browser for the user to login in, and makes no sense for API calls on the background.
- Logout button had two functionalities: it started a logout flow, and was a link to the main page. This caused a race condition, where the main page load and logout redirect to google sign-in where competing.

Not 100% sure that this will fix all the issues in the logout flow, but on bstaging/r11-alt it seems to work on a similar setup. This can be tried there.


