### PR TITLE
Faster manhattans

### DIFF
--- a/wdl/import.wdl
+++ b/wdl/import.wdl
@@ -288,9 +288,7 @@ task pheno {
         pheweb phenolist extract-phenocode-from-filepath --simple && \
         pheweb augment-phenos && \
         pheweb manhattan && \
-        ([[ -z "${gnomad_filepath}" ]] || \
-        [[ -z "${annotation_filepath}" ]] || \
-        pheweb annotate-manhattan --gnomad_filepath=${gnomad_filepath} --annotation_filepath=${annotation_filepath} --compress=${compress_flag}) && \
+        ([[ "${compress_flag}" == "false" ]] || gzip generated-by-pheweb/manhattan/${pheno_name}.json) && \
         pheweb qq && \
         pheweb bgzip-phenos &&
         find ./

--- a/wdl/import.wdl
+++ b/wdl/import.wdl
@@ -243,15 +243,9 @@ task pheno {
     File bed_file
 	Int gene_version
 
-    File? gnomad_filepath
-    File? annotation_filepath
-    File? gnomad_filepath_tbi = gnomad_filepath + ".tbi"
-    File? annotation_filepath_tbi = annotation_filepath + ".tbi"
-
     String base_name = sub(basename(pheno_file), file_affix, "")
     String pheno_name = sub(base_name, ".gz$", "")
 
-    Boolean annotate_manhattan = defined(gnomad_filepath) && defined(annotation_filepath) && defined(gnomad_filepath_tbi) && defined(annotation_filepath_tbi)
 	Boolean compress_manhattan = false
 
 	# translate manhattan flags

--- a/wdl/manhattan.wdl
+++ b/wdl/manhattan.wdl
@@ -1,0 +1,57 @@
+task manhattan {
+    String docker
+    File pheno_file
+
+    String pheno_name = sub(basename(pheno_file), ".gz$", "")
+    String manhattan_file = "pheweb/generated-by-pheweb/manhattan/${pheno_name}.json.gz"
+
+    command <<<
+        set -euxo pipefail
+
+        mkdir -p pheweb/generated-by-pheweb/parsed
+        mkdir -p pheweb/generated-by-pheweb/pheno
+        mkdir -p /root/.pheweb/cache
+
+        cat ${pheno_file} | \
+        (if [[ "${pheno_file}" == *.gz || "${pheno_file}" == *.bgz ]]; then zcat ; else cat ; fi) | \
+        sed '1 s/^#chrom/chrom/ ; ' > pheweb/generated-by-pheweb/parsed/${pheno_name}
+
+        cp pheweb/generated-by-pheweb/parsed/${pheno_name} pheweb/generated-by-pheweb/pheno/${pheno_name}
+
+        cd pheweb
+
+        pheweb phenolist glob generated-by-pheweb/parsed/* --simple-phenocode && \
+        pheweb manhattan && \
+        gzip generated-by-pheweb/manhattan/${pheno_name}.json
+    >>>
+
+    output {
+        File out = manhattan_file
+    }
+
+    runtime {
+        docker: "${docker}"
+        cpu: 2
+        memory: "4 GB"
+        bootDiskSizeGb: 30
+        disks: "local-disk 70 HDD"
+        zones: "europe-west1-b"
+        preemptible: 2
+    }
+}
+
+workflow generate_manhattan {
+
+    File pheno_file_loc
+    Array[String] pheno_files = read_lines(pheno_file_loc)
+
+    scatter (pheno_file in pheno_files) {
+        call manhattan {
+            input: pheno_file = pheno_file
+        }
+    }
+
+    output {
+        Array[File] manhattan = manhattan.out
+    }
+}

--- a/wdl/manhattan_wdl_input.json
+++ b/wdl/manhattan_wdl_input.json
@@ -1,0 +1,4 @@
+{
+  "generate_manhattan.manhattan.docker": "europe-west1-docker.pkg.dev/phewas-development/fg-phewas-registry/pheweb:<docker image tag>",
+  "generate_manhattan.pheno_file_loc": "gs://path to a text file with all pheno file locations, one per line"
+}


### PR DESCRIPTION
Updated the WDL:s for new manhattan generation. 

1. Basic import.wdl updated. Just removed the annotation command, as this is unnecessary and makes the manhattan file larger. 
2. Added manhattan.wdl for generating just the manhattans for older phewebs