### PR TITLE
Mobile UI

### DIFF
--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -3,6 +3,7 @@
       itemtype="http://schema.org/WebPage"
       lang="en">
   <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- configuration -->
     <link href="https://cdn.jsdelivr.net/npm/locuszoom@0.10.2/dist/locuszoom.css" rel="stylesheet">
     <script src="%REACT_APP_CONFIG_URL%" type="text/javascript"></script>

--- a/ui/src/common/CommonDownloadTable.tsx
+++ b/ui/src/common/CommonDownloadTable.tsx
@@ -59,6 +59,7 @@ const CommonDownloadTable = <TableData,RowType extends {}>
       }
     }
     const body = <div>
+      <div style={{ overflowX: 'auto', width: '100%' }}>
       <ReactTable
         ref={setReactTableRef}
         data={dataToTableRows(tableData)}
@@ -68,6 +69,7 @@ const CommonDownloadTable = <TableData,RowType extends {}>
         SubComponent={subComponent}
         getTrProps={getTrProps}
         {...tableProperties  } />
+      </div>
       <p>
 
       </p>

--- a/ui/src/common/CommonDownloadTable.tsx
+++ b/ui/src/common/CommonDownloadTable.tsx
@@ -73,10 +73,8 @@ const CommonDownloadTable = <TableData,RowType extends {}>
       <p>
 
       </p>
-      <div className="row">
-        <div className="col-xs-12">
-          <div className="btn btn-primary" onClick={downloadHandler}>Download table</div>
-        </div>
+      <div>
+        <div className="btn btn-primary" onClick={downloadHandler}>Download table</div>
       </div>
 
       <CSVLink

--- a/ui/src/common/commonTableColumn.tsx
+++ b/ui/src/common/commonTableColumn.tsx
@@ -91,9 +91,9 @@ const betaVariantTableFormatter = (props) => {
     result =  (+props.value).toExponential(1);
   } else if (props.value === null ){
     result =  (
-      <p style={{ fontWeight: 'bold', minWidth: props.width * 3,
-                  textAlign: 'center', position: 'absolute',
-                  overflow: 'overlay'}}>Not significant. Click to see stats</p>
+      <p style={{ fontWeight: 'bold', whiteSpace: 'nowrap',
+                  textAlign: 'left',
+                }}>Not significant. Click to see stats</p>
     )
   } else {
     result = props.value;
@@ -1537,7 +1537,8 @@ const phenotypeColumns = {
     accessor: "beta",
     id: 'beta',
     minWidth: 5 * emsize ,
-    width: 5 * emsize
+    width: 5 * emsize,
+    style: { overflow: 'visible' },
   },
   phenocode: {
       Header: () => (<span title="phenocode" style={{ textDecoration: "underline" }}>phenocode</span>),

--- a/ui/src/components/Coding/features/table/ResultTable.tsx
+++ b/ui/src/components/Coding/features/table/ResultTable.tsx
@@ -646,6 +646,7 @@ export const ResultTable = () => {
           arrowColor="transparent"
           html={true}
         />
+        <div style={{ overflowX: 'auto', width: '100%' }}>
         <table className="codingTable" {...getTableProps()}>
           <thead>
             {headerGroups.map((headerGroup) => (
@@ -701,6 +702,7 @@ export const ResultTable = () => {
             })}
           </tbody>
         </table>
+        </div>
         <div className="pagination">
           <button onClick={() => gotoPage(0)} disabled={!canPreviousPage}>
             {"<<"}

--- a/ui/src/components/Coding/style.css
+++ b/ui/src/components/Coding/style.css
@@ -6,8 +6,6 @@ div:has(> #only-chip-label) {
 }
 .coding div {
   font-family: "Open Sans", sans-serif;
-  font-size: 0.8vw;
-  padding: 10px;
 }
 
 .coding .container {

--- a/ui/src/components/Gene/Gene.tsx
+++ b/ui/src/components/Gene/Gene.tsx
@@ -61,7 +61,9 @@ const GeneContent = () => {
     }
     <div id={showTableOfContents ? tableOfContentsComponentIds['associationResults'] : null}>
       <GenePhenotypeAssociation/>
-      <GeneLocusZoom />
+      <div style={{ overflowX: 'auto', width: '100%' }}>
+        <GeneLocusZoom />
+      </div>
     </div>
     <div id={showTableOfContents ? tableOfContentsComponentIds['geneFunctionalVariants'] : null}>
       <GeneFunctionalVariants/>

--- a/ui/src/components/Gene/GenePhenotypeAssociation.tsx
+++ b/ui/src/components/Gene/GenePhenotypeAssociation.tsx
@@ -13,10 +13,8 @@ import "./gene.css";
 
 
 const default_banner: string = `
-<div class="row">
-  <div class="col-md-10 col-lg-10 col-sm-10 col-xs-10">
-    <h3>Association results</h3>
-  </div>
+<div>
+  <h3>Association results</h3>
 </div>
 `
 

--- a/ui/src/components/Gene/GenePhenotypeAssociationSelected.tsx
+++ b/ui/src/components/Gene/GenePhenotypeAssociationSelected.tsx
@@ -7,12 +7,10 @@ interface Props {}
 
 const default_footer: string = `
 {{#selectedPhenotype}}
-<div class="row">
-    <div class="pheno-info col-xs-12">
-      <p style="margin-bottom: 0"><b>{{assoc.phenostring}}</b></p>
-          <p style="margin-bottom: 0"><b>{{assoc.n_case}}</b> cases, <b>{{assoc.n_control}}</b> controls</p>
-          <p style="margin-bottom: 0">{{assoc.category}}</p>
-    </div>
+<div class="pheno-info">
+  <p style="margin-bottom: 0"><b>{{assoc.phenostring}}</b></p>
+  <p style="margin-bottom: 0"><b>{{assoc.n_case}}</b> cases, <b>{{assoc.n_control}}</b> controls</p>
+  <p style="margin-bottom: 0">{{assoc.category}}</p>
 </div>
 {{/selectedPhenotype}}
 `

--- a/ui/src/components/HLA/HLASearch.tsx
+++ b/ui/src/components/HLA/HLASearch.tsx
@@ -34,11 +34,13 @@ const reshapeResult = (result: AutoCompleteModel.Row) => {
 const customStyles = {
     container: provided => ({
         ...provided,
-        width: 500
+        width: 500,
+        maxWidth: '90vw',
     }),
     control: provided => ({
         ...provided,
         width: 500,
+        maxWidth: '90vw',
         height: 10
     }),
 }
@@ -52,7 +54,7 @@ const Search = () => {
     )
     return (<form className="form-inline">
         <Select
-            placeholder={'Show all HLA results for a variant, gene, or phenotype'}
+            placeholder={'Search by variant, gene, or phenotype'}
             onChange={onChange}
             options={autoCompleteOptions}
             menuPosition="fixed"

--- a/ui/src/components/Nav/Search.tsx
+++ b/ui/src/components/Nav/Search.tsx
@@ -43,11 +43,13 @@ const loadOptions = (query: string,callBack) => {
 const customStyles = {
   container: provided => ({
     ...provided,
-    width: 400
+    maxWidth: '95vw',
+    width: 400,
   }),
   control: provided => ({
     ...provided,
     width: 400,
+    maxWidth: '95vw',
     height: 10
   }),
 }

--- a/ui/src/components/Phenotype/PhenotypeCSTable.tsx
+++ b/ui/src/components/Phenotype/PhenotypeCSTable.tsx
@@ -13,7 +13,7 @@ type LocusGroups =  [{ [locus_id: string]: LocusGroupEntry }];
 declare let window: ConfigurationWindow;
 const configuration = window?.config?.userInterface?.phenotype?.credibleSet;
 
-const defaultSorted = configuration?.table?.defaultSorted || [{ id: 'pval', desc: false }];
+const defaultSorted = configuration?.table?.defaultSorted || [{ id: 'cs_prob', desc: true }, { id: 'r2_to_lead', desc: true }];
 
 const r2leadThreshold = window?.config?.userInterface?.phenotype?.r2_to_lead_threshold;
 

--- a/ui/src/components/Phenotype/PhenotypeGWASPlot.tsx
+++ b/ui/src/components/Phenotype/PhenotypeGWASPlot.tsx
@@ -12,7 +12,11 @@ const PhenotypeGWASPlot = () => {
     createGWASPlot(phenotypeCode, phenotypeVariantData.variant_bins, phenotypeVariantData.unbinned_variants);
   }, [phenotypeCode, phenotypeVariantData])
 
-  return <div id='manhattan_plot_container'/>;
+  return (
+    <div style={{ overflowX: 'auto'}}>
+      <div id='manhattan_plot_container'/>
+    </div>
+  );
 }
 
 export default PhenotypeGWASPlot;

--- a/ui/src/components/Phenotype/PhenotypeGWASPlot.tsx
+++ b/ui/src/components/Phenotype/PhenotypeGWASPlot.tsx
@@ -13,7 +13,7 @@ const PhenotypeGWASPlot = () => {
   }, [phenotypeCode, phenotypeVariantData])
 
   return (
-    <div style={{ overflowX: 'auto'}}>
+    <div style={{ overflowX: 'auto', width: '100%' }}>
       <div id='manhattan_plot_container'/>
     </div>
   );

--- a/ui/src/components/Phenotype/PhenotypeQQPlot.tsx
+++ b/ui/src/components/Phenotype/PhenotypeQQPlot.tsx
@@ -26,9 +26,9 @@ const PhenotypeQQPlot = () => {
       createQQPlot([{ maf_range: [0, 1], qq: qq.overall.qq, count: qq.overall.count }])
     }
     return <>
-      <div style={{ float: 'left' }}>
+      <div>
         <h3>QQ plot</h3>
-        <div id='qq_plot_container' style={{ width: '400px' }} />
+        <div id='qq_plot_container' style={{ width: '100%', maxWidth: '400px' }} />
         {qqTable}
       </div>
     </>;

--- a/ui/src/components/Region/Colocalization/Colocalization.css
+++ b/ui/src/components/Region/Colocalization/Colocalization.css
@@ -47,6 +47,7 @@
     font-size: 16px;
     cursor: pointer;
     width: 350px;
+    max-width: 80vw;
     height: 25px;
     align-items: center;
     display: flex;

--- a/ui/src/components/Region/Colocalization/ColocalizationList.tsx
+++ b/ui/src/components/Region/Colocalization/ColocalizationList.tsx
@@ -181,20 +181,15 @@ const ColocalizationList = (props : Props) => {
                          className="-striped -highlight"
                          useFlexLayout />
             <p></p>
-            <div className="row">
-                <div className="col-xs-12">
-                    <CSVLink
-                        headers={headers(listMetadata)}
-                        data={ colocFiltBySource.map(flatten) }
-                        separator={'\t'}
-                        enclosingCharacter={''}
-                        filename={`colocalization.tsv`}
-                        className="btn btn-primary"
-                        target="_blank">Download Table
-                    </CSVLink>
-                </div>
-
-            </div>
+            <CSVLink
+                headers={headers(listMetadata)}
+                data={ colocFiltBySource.map(flatten) }
+                separator={'\t'}
+                enclosingCharacter={''}
+                filename={`colocalization.tsv`}
+                className="btn btn-primary"
+                target="_blank">Download Table
+            </CSVLink>
         </div>);
     } else {
         return (<div>Loading ... </div>);

--- a/ui/src/components/Region/LocusZoom/RegionLayouts.tsx
+++ b/ui/src/components/Region/LocusZoom/RegionLayouts.tsx
@@ -98,7 +98,7 @@ export const region_layout: (region: Region) => Layout = (region: Region) => {
 
 		width: width,
 		height: 800,
-		"min_width": width,
+		"min_width": 800,
 	    "min_height": 100,
 		responsive_resize: 'both',
 		"resizable": "responsive",

--- a/ui/src/components/Region/Region.css
+++ b/ui/src/components/Region/Region.css
@@ -49,6 +49,7 @@ div.lz-data_layer-tooltip th, div.lz-data_layer-tooltip td {
     display: flex;
     flex-direction: row;
     align-items: center;
+    flex-wrap: wrap;
 }
 
 .arrow-container {

--- a/ui/src/components/Region/Region.tsx
+++ b/ui/src/components/Region/Region.tsx
@@ -17,8 +17,7 @@ type Props = RouteComponentProps<RegionParams>;
 const RegionContent = () => {
   const { error } = useRegionContext();
 
-  const content = <div id="b85c6b35-146e-438d-a38a-2a80cd3b46f6" className="container-fluid"
-       style={{ width: "95%" }}>
+  const content = <div>
     <RegionBanner />
     <RegionSummary />
     <RegionSelection />

--- a/ui/src/components/Region/Region.tsx
+++ b/ui/src/components/Region/Region.tsx
@@ -23,7 +23,9 @@ const RegionContent = () => {
     <RegionSummary />
     <RegionSelection />
     <RegionMessage />
-    <RegionLocusZoom />
+    <div style={{ overflowX: 'auto', width: '100%' }}>
+      <RegionLocusZoom />
+    </div>
     <RegionColocalization />
   </div>
 

--- a/ui/src/components/Region/RegionBanner.tsx
+++ b/ui/src/components/Region/RegionBanner.tsx
@@ -8,19 +8,16 @@ const RegionBanner =  (props : Props) => {
     if(region) {
         const phenotype = region.phenotype;
 
-        return (<div className="row">
-            <div className="col-xs-12">
-            { /* RegionBanner */ }
+        return (<div>
                 <h1>{phenotype && phenotype.phenostring} </h1>
-                    <p>
-                        <a href={`https://risteys.finregistry.fi/phenocode/${phenotype.phenocode}`}
-                           rel="noopener noreferrer"
-			   target="_blank">RISTEYS</a>
-                    </p>
-                </div>
+                <p>
+                    <a href={`https://risteys.finregistry.fi/phenocode/${phenotype.phenocode}`}
+                       rel="noopener noreferrer"
+                       target="_blank">RISTEYS</a>
+                </p>
             </div>);
     } else {
-        return (<div className="col-xs-12"></div>);
+        return (<div></div>);
     }
 
 }

--- a/ui/src/components/Region/RegionLocusZoom.tsx
+++ b/ui/src/components/Region/RegionLocusZoom.tsx
@@ -25,14 +25,11 @@ const RegionLocusZoom =  (props : Props) => {
     },[locusZoomData, region, setLocusZoomContext]);
 
     if(region) {
-        return (<div className="row">
-            <div className="col-xs-12">
-                <div id="lz-1" className="lz-locuszoom-container lz-container-responsive" data-region={ locusToStr(region.region) }></div>
-            </div>
-        </div>);
-
+        return (
+            <div id="lz-1" className="lz-locuszoom-container lz-container-responsive" data-region={ locusToStr(region.region) } style={{ minWidth: '800px' }}></div>
+        );
     } else {
-        return (<div className="row"></div>);
+        return (<div></div>);
     }
 
 }

--- a/ui/src/components/Region/RegionMessage.tsx
+++ b/ui/src/components/Region/RegionMessage.tsx
@@ -9,13 +9,11 @@ const p_threshold = config?.lz_configuration?.p_threshold;
 
 const RegionMessage =  (props : Props) => {
     if(p_threshold) {
-        return (<div className="row">
-                    <div className="col-xs-12">
-                        <p>Variants with a p-value smaller {p_threshold} than are shown</p>
-                    </div>
+        return (<div>
+                    <p>Variants with a p-value smaller {p_threshold} than are shown</p>
                 </div>);
     } else {
-        return (<div className="row"></div>);
+        return (<div></div>);
     }
 
 }

--- a/ui/src/components/Region/RegionSummary.tsx
+++ b/ui/src/components/Region/RegionSummary.tsx
@@ -8,15 +8,13 @@ const RegionSummary =  (props : Props) => {
     const { region } = useContext<Partial<RegionState>>(RegionContext);
     if(region) {
         const { phenotype } = region;
-        return (<div className="row">
-            <div id={"23813672-798b-46ec-a8ad-4eb2bf72b328"} className="pheno-info col-xs-12">
+        return (<div className="pheno-info">
                 <p><b>{phenotype.num_cases}</b> cases, <b>{phenotype.num_controls}</b> controls</p>
                 <p>{phenotype.category}</p>
                 { <RegionFinemapSummary/>}
-            </div>
-        </div>)
+            </div>)
     } else {
-        return (<div className="row"/>);
+        return (<div/>);
     }
 }
 

--- a/ui/src/components/Variant/Variant.tsx
+++ b/ui/src/components/Variant/Variant.tsx
@@ -511,7 +511,7 @@ const Variant = (props : Props) => {
       {'results' in variantData && <VariantLavaaPlot variantData={variantDataPlots}/>}
       </div>
 
-      <div>
+      <div style={{ overflowX: 'auto'}}>
         {'results' in variantData && <VariantLocusZoom variantData={variantDataPlots}/>}
       </div>
 

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -19,6 +19,7 @@ import './assets/common.css'
 import './assets/react-style.css'
 import 'locuszoom/dist/locuszoom.css'
 import 'bootstrap/dist/css/bootstrap.min.css'
+import 'bootstrap/dist/js/bootstrap.bundle.min'
 import Nav from './components/Nav/Nav'
 
 const element = document.getElementById('root')


### PR DESCRIPTION
Some additions and deletions to make Pheweb usable on mobile. 

I've tried to:
- make every page usable on mobile, while keeping browser ui as-is (or better in few small details)
- the full page should not scroll horizontally on mobile, but instead fit the screen
- plots and tables should scroll horizontally on mobile, without scrolling the whole page

Pages fixed are main page, phenotype, region, variant, gene, hla and coding. Lavaa plot on variant page does not work on mobile. The code is in another package and needs changes there.

Did also some minor tweaks to the UI, like fixing margins where they were missing and unified all outer margins to 10px (before they varied depending on the page).

also contains the fix to sort credible sets correctly, which was raised in slack. 