### PR TITLE
Fix Manhattan generation for HLA region

### DIFF
--- a/pheweb/load/manhattan.py
+++ b/pheweb/load/manhattan.py
@@ -139,8 +139,12 @@ def bin_variants(variant_iterator, bin_length, neglog10_pval_bin_size, neglog10_
         else:
             bin_variant(v)
     
-    for v in filter(lambda x: x['pval']<=max_p['pval'], add_hla ):
-        final_unbinned_variants.append(v)
+    # unbin hla variants if they are at least as significant as the least significant variant included. bin the rest
+    for v in add_hla:
+        if v['pval'] < max_p['pval']:
+            final_unbinned_variants.append(v)
+        else:
+            bin_variant(v)
 
     # unroll bins into simple array (preserving chromosomal order)
     binned_variants = []

--- a/tests/pheweb/load/test_manhattan.py
+++ b/tests/pheweb/load/test_manhattan.py
@@ -221,6 +221,18 @@ class TestHLAVariants:
         _, unbinned = _call(variants, manhattan_hla_num_unbinned=5)
         assert not any(v['pval'] == 0.1 for v in unbinned)
 
+    def test_hla_binned_correctly(self):
+        variants = [
+            _v('6', 26_500_000, 0.05, mlogp=1.5),   # HLA, more sig, stays in hla_pq, binned
+            _v('6', 27_000_000, 0.1, mlogp=1.0),    # HLA, less sig, binned
+            _v('6', 27_500_000, 0.001, mlogp=3.0),  # HLA, most sig, unbinned
+            _v('1', 1_000_000, 0.01, mlogp=2.0),    # non-HLA anchor
+        ]
+        binned, unbinned = _call(variants, manhattan_hla_num_unbinned=2)
+        # two of the HLA variants should be binned, one unbinned
+        assert len(binned) == 2
+        assert len(unbinned) == 2
+
     def test_chrom6_variant_outside_hla_region_treated_as_non_hla(self):
         # Variant on chrom 6 but position is before hla_begin
         variants = [


### PR DESCRIPTION
This should fix the issue https://github.com/FINNGEN/pheweb/issues/643

Added a short fix to the manhattan generation. Variants in the HLA region were dropped if they were not binned on the first round of HLA region prioritization, but not significant enough to make it to the final unbinned list.

in the new Parkinson plot we can see the missing binned variants (taken from my test server):
<img width="74" height="319" alt="image" src="https://github.com/user-attachments/assets/3bc447c2-c701-479d-87c8-aac6db639c9d" />
