### PR TITLE
Unifying risteys link behavior

### DIFF
--- a/ui/public/config.js
+++ b/ui/public/config.js
@@ -48,26 +48,6 @@ const userInterface = {
   hla: {},
   about: { banner: aboutBanner },
   phenotype: {
-    banner: `
-    <h2 style="margin-top: 0;">
-        {{phenostring}}
-       </h2>
-        <p>{{category}}</p>
-        <p style="margin-bottom: 10px;">
-        <a style="
-        font-size: 1.25rem;
-        padding: .25rem .5rem;
-        background-color: #2779bd;
-        color: #fff;
-        border-radius: .25rem;
-        font-weight: 700;
-    box-shadow: 0 0 5px rgba(0,0,0,.5);"
-           rel="noopener noreferrer"
-           href="https://risteys.finregistry.fi/phenocode/{{risteys}}"
-           target="_blank">RISTEYS
-        </a>
-      </p>
-    `,
     r2_to_lead_threshold: 0.6,
   },
   index: {

--- a/ui/src/common/commonModel.tsx
+++ b/ui/src/common/commonModel.tsx
@@ -213,7 +213,10 @@ export interface Phenotype {
   num_gw_significant?: number
   phenocode: string
   phenostring: string
-  risteys?: string
+  hasRisteys?: string
+  risteysURL?: string
+  risteysPhenocode?: string
+  risteysURLPrefix?: string
   is_binary?: boolean
 }
 

--- a/ui/src/common/commonTableColumn.tsx
+++ b/ui/src/common/commonTableColumn.tsx
@@ -154,7 +154,7 @@ const variantCell = (value : string) => {
  * @param {string} risteysURL - The URL to be linked.
  * @returns {JSX.Element} A styled anchor element pointing to the provided URL.
  */
-export const risteysLinkFormatter = (risteysURL : string) => <a style={{
+export const risteysLinkFormatter = (risteysURL : string) => risteysURL ? <a style={{
         fontSize: "1.25rem",
         padding: ".25rem .5rem",
         backgroundColor: "#2779bd",
@@ -163,7 +163,7 @@ export const risteysLinkFormatter = (risteysURL : string) => <a style={{
         fontWeight: 700,
         boxShadow: "0 0 5px rgba(0,0,0,.5)"
     }}
-    href={risteysURL}>RISTEYS</a>
+    href={risteysURL}>RISTEYS</a> : <></>
 
 /**
  * Formats a Risteys URL based on the provided props.
@@ -172,13 +172,14 @@ export const risteysLinkFormatter = (risteysURL : string) => <a style={{
  * @param {string} props.value - return null if the phenocode should not have a Risteys link.
  */
 export const risteysURLFormatter = (props) => {
-    const row = props.row;
+    // to avoid adding the hidden helper columns into the table, let's read them from 'original' field
+    const row = props.original ?? props.row;
     const phenocode=row?.phenocode?.replace("_EXALLC", "").replace("_EXMORE", "");
-    const hasRisteys=(typeof(row?.hasRisteys) === "boolean") ? row?.hasRisteys         : true;
-    const risteysPhenocode=row?.risteysPhenocode             ? row?.risteysPhenocode   : phenocode;
-    const risteysURLPrefix=row?.risteysURLPrefix             ? row?.risteysURLPrefix   : defaultRisteysURLPrefix;
-    const risteysURL : string=row?.risteysURL                ? row?.risteysURL         : `${risteysURLPrefix}${risteysPhenocode}`;
-    return hasRisteys?risteysURL:null;
+    const hasRisteys=(typeof(row.hasRisteys) === "boolean") ? row.hasRisteys : true;
+    const risteysPhenocode = row.risteysPhenocode ?? phenocode;
+    const risteysURLPrefix = row.risteysURLPrefix  ?? defaultRisteysURLPrefix;
+    const risteysURL = row.risteysURL ?? `${risteysURLPrefix}${risteysPhenocode}`;
+    return hasRisteys ? risteysURL : null;
 }
 
 /**
@@ -199,7 +200,7 @@ export const risteysURLFormatter = (props) => {
  */
 export const risteysLinkCell = (props) => {
     const risteysURL=risteysURLFormatter(props)
-    return risteysURL?risteysLinkFormatter(risteysURL):<></>;
+    return risteysLinkFormatter(risteysURL)
 }
 
 interface FunctionalVariantFinnGen {

--- a/ui/src/common/commonTableColumn.tsx
+++ b/ui/src/common/commonTableColumn.tsx
@@ -165,7 +165,6 @@ export const risteysLinkFormatter = (risteysURL : string) => <a style={{
     }}
     href={risteysURL}>RISTEYS</a>
 
-
 /**
  * Formats a Risteys URL based on the provided props.
  *

--- a/ui/src/common/commonTableColumn.tsx
+++ b/ui/src/common/commonTableColumn.tsx
@@ -165,6 +165,7 @@ export const risteysLinkFormatter = (risteysURL : string) => <a style={{
     }}
     href={risteysURL}>RISTEYS</a>
 
+
 /**
  * Formats a Risteys URL based on the provided props.
  *
@@ -172,8 +173,8 @@ export const risteysLinkFormatter = (risteysURL : string) => <a style={{
  * @param {string} props.value - return null if the phenocode should not have a Risteys link.
  */
 export const risteysURLFormatter = (props) => {
-    const phenocode=props?.value?.replace("_EXALLC", "").replace("_EXMORE", "");
     const row = props.row;
+    const phenocode=props?.phenocode?.replace("_EXALLC", "").replace("_EXMORE", "");
     const hasRisteys=(typeof(row?.hasRisteys) === "boolean") ? row?.hasRisteys         : true;
     const risteysPhenocode=row?.risteysPhenocode             ? row?.risteysPhenocode   : phenocode;
     const risteysURLPrefix=row?.risteysURLPrefix             ? row?.risteysURLPrefix   : defaultRisteysURLPrefix;

--- a/ui/src/common/commonTableColumn.tsx
+++ b/ui/src/common/commonTableColumn.tsx
@@ -174,7 +174,7 @@ export const risteysLinkFormatter = (risteysURL : string) => <a style={{
  */
 export const risteysURLFormatter = (props) => {
     const row = props.row;
-    const phenocode=props?.phenocode?.replace("_EXALLC", "").replace("_EXMORE", "");
+    const phenocode=row?.phenocode?.replace("_EXALLC", "").replace("_EXMORE", "");
     const hasRisteys=(typeof(row?.hasRisteys) === "boolean") ? row?.hasRisteys         : true;
     const risteysPhenocode=row?.risteysPhenocode             ? row?.risteysPhenocode   : phenocode;
     const risteysURLPrefix=row?.risteysURLPrefix             ? row?.risteysURLPrefix   : defaultRisteysURLPrefix;

--- a/ui/src/components/Phenotype/PhenotypeBanner.tsx
+++ b/ui/src/components/Phenotype/PhenotypeBanner.tsx
@@ -6,20 +6,20 @@ import { PhenotypeContext, PhenotypeState } from "./PhenotypeContext";
 import { Phenotype } from "./../../common/commonModel";
 
 interface Props {}
-const default_banner = `
+const banner = `
         <h2 style="marginTop: 0">
         {{phenostring}}
         </h2>
         <p>{{category}}</p>
 
-        {{#risteys}}
+        {{#risteysURL}}
         <p style="margin-bottom: 10px;">
-           <a href="https://risteys.finregistry.fi/phenocode/{{.}}"
+           <a href="{{.}}"
               target="_blank"
               class="risteys">RISTEYS
            </a>
         </p>
-        {{/risteys}}
+        {{/risteysURL}}
 
         <table class="column_spacing">
            <tbody>
@@ -36,7 +36,6 @@ const default_banner = `
 
 declare let window: ConfigurationWindow;
 const { config } = window;
-const banner: string = config?.userInterface?.phenotype?.banner || default_banner;
 
 const PhenotypeBanner = (props : Props) => {
   const { phenotype } = useContext<Partial<PhenotypeState>>(PhenotypeContext);

--- a/ui/src/components/Phenotype/PhenotypeBanner.tsx
+++ b/ui/src/components/Phenotype/PhenotypeBanner.tsx
@@ -15,8 +15,17 @@ const banner = `
         {{#risteysURL}}
         <p style="margin-bottom: 10px;">
            <a href="{{.}}"
-              target="_blank"
-              class="risteys">RISTEYS
+           style="
+            font-size: 1.25rem;
+            padding: .25rem .5rem;
+            background-color: #2779bd;
+            color: #fff;
+            border-radius: .25rem;
+            font-weight: 700;
+            box-shadow: 0 0 5px rgba(0,0,0,.5);"
+           target="_blank"
+           rel="noopener noreferrer"
+           target="_blank">RISTEYS
            </a>
         </p>
         {{/risteysURL}}
@@ -36,7 +45,6 @@ const banner = `
 
 declare let window: ConfigurationWindow;
 const { config } = window;
-
 const PhenotypeBanner = (props : Props) => {
   const { phenotype } = useContext<Partial<PhenotypeState>>(PhenotypeContext);
   const content = () => mustacheDiv<Phenotype>(banner, phenotype)

--- a/ui/src/components/Phenotype/PhenotypeBanner.tsx
+++ b/ui/src/components/Phenotype/PhenotypeBanner.tsx
@@ -1,55 +1,28 @@
 import { useContext } from "react";
 import { isLoading } from "../../common/CommonLoading";
-import { mustacheDiv } from "../../common/commonUtilities"
-import { ConfigurationWindow } from "../Configuration/configurationModel"
 import { PhenotypeContext, PhenotypeState } from "./PhenotypeContext";
-import { Phenotype } from "./../../common/commonModel";
+import React from "react";
+import { risteysLinkFormatter } from "../../common/commonTableColumn";
 
 interface Props {}
-const banner = `
-        <h2 style="marginTop: 0">
-        {{phenostring}}
-        </h2>
-        <p>{{category}}</p>
 
-        {{#risteysURL}}
-        <p style="margin-bottom: 10px;">
-           <a href="{{.}}"
-           style="
-            font-size: 1.25rem;
-            padding: .25rem .5rem;
-            background-color: #2779bd;
-            color: #fff;
-            border-radius: .25rem;
-            font-weight: 700;
-            box-shadow: 0 0 5px rgba(0,0,0,.5);"
-           target="_blank"
-           rel="noopener noreferrer"
-           target="_blank">RISTEYS
-           </a>
-        </p>
-        {{/risteysURL}}
-
-        <table class="column_spacing">
-           <tbody>
-              {{#num_cases}}
-              <tr><td><b>{{.}}</b> cases</td></tr>
-              {{/num_cases}}
-
-              {{#num_controls}}
-              <tr><td><b>{{.}}</b> controls</td></tr>
-              {{/num_controls}}
-           </tbody>
-        </table>
-  `
-
-declare let window: ConfigurationWindow;
-const { config } = window;
 const PhenotypeBanner = (props : Props) => {
   const { phenotype } = useContext<Partial<PhenotypeState>>(PhenotypeContext);
-  const content = () => mustacheDiv<Phenotype>(banner, phenotype)
-  return isLoading(phenotype === null || phenotype === undefined,content);
-
+  const content = () => (
+   <div><h2 style={{marginTop: 0}}>
+        {phenotype?.phenostring}
+    </h2>
+        <p>{phenotype?.category}</p>
+   {risteysLinkFormatter(phenotype.risteysURL)}
+   <table className="column_spacing">
+           <tbody>
+              <tr><td><b>{phenotype?.num_cases}</b> cases</td></tr>
+              <tr><td><b>{phenotype?.num_controls}</b> controls</td></tr>
+           </tbody>
+        </table>
+   </div>
+  )
+  return isLoading(phenotype === null || phenotype === undefined, content);
 }
 
 export default PhenotypeBanner

--- a/ui/src/components/Phenotype/phenotype.css
+++ b/ui/src/components/Phenotype/phenotype.css
@@ -1,14 +1,3 @@
-a.risteys {
-    font-size: 1.25rem;
-    padding: 0.25rem 0.5rem;
-    background-color: rgb(39, 121, 189);
-    color: rgb(255, 255, 255);
-    border-radius: 0.25rem;
-    font-weight: 700;
-    box-shadow: rgba(0, 0, 0, 0.5) 0px 0px 5px;
-}
-
-
 .phenotype-tab {
     height: 100%;
     width: 100%;

--- a/ui/src/components/Phenotype/phenotypeAPI.tsx
+++ b/ui/src/components/Phenotype/phenotypeAPI.tsx
@@ -1,8 +1,11 @@
 import { Phenotype } from "./../../common/commonModel";
 import { compose, get, Handler } from "../../common/commonUtilities";
 import { CredibleSet, LocusGroupEntry, PhenotypeVariantData, QQ } from "./phenotypeModel";
-import { resolveURL } from "../Configuration/configurationModel";
-import { pValueSentinel } from "../../common/commonTableColumn";
+import { ConfigurationWindow, resolveURL } from "../Configuration/configurationModel";
+import { pValueSentinel, risteysURLFormatter } from "../../common/commonTableColumn";
+
+declare let window: ConfigurationWindow;
+const defaultRisteysURLPrefix = window?.config?.application?.risteysURLPrefix||'https://risteys.finregistry.fi/phenocode/';
 
 const reshapeManhattan = (phenotypeCode: string) =>(data : PhenotypeVariantData) : PhenotypeVariantData => {
   if(data === null || data === undefined) return data;
@@ -50,7 +53,12 @@ export const getManhattan= (phenotypeCode: string,
 }
 
 const addRisteys = (phenotype : Phenotype) => {
-  phenotype.risteys = phenotype.phenocode.replace('_EXMORE', '');
+  const phenocode=phenotype?.phenocode?.replace("_EXALLC", "").replace("_EXMORE", "");
+  const hasRisteys=(typeof(phenotype?.hasRisteys) === "boolean") ? phenotype?.hasRisteys         : true;
+  const risteysPhenocode=phenotype?.risteysPhenocode             ? phenotype?.risteysPhenocode   : phenocode;
+  const risteysURLPrefix=phenotype?.risteysURLPrefix             ? phenotype?.risteysURLPrefix   : defaultRisteysURLPrefix;
+  const risteysURL : string=phenotype?.risteysURL                ? phenotype?.risteysURL         : `${risteysURLPrefix}${risteysPhenocode}`;
+  phenotype.risteysURL = hasRisteys ? risteysURL : null;
   return phenotype;
 }
 

--- a/ui/src/components/Phenotype/phenotypeAPI.tsx
+++ b/ui/src/components/Phenotype/phenotypeAPI.tsx
@@ -53,7 +53,7 @@ export const getManhattan= (phenotypeCode: string,
 }
 
 const addRisteys = (phenotype : Phenotype) => {
-  phenotype.risteysURL = risteysURLFormatter(phenotype);
+  phenotype.risteysURL = risteysURLFormatter({row: phenotype});
   return phenotype
 }
 

--- a/ui/src/components/Phenotype/phenotypeAPI.tsx
+++ b/ui/src/components/Phenotype/phenotypeAPI.tsx
@@ -53,13 +53,8 @@ export const getManhattan= (phenotypeCode: string,
 }
 
 const addRisteys = (phenotype : Phenotype) => {
-  const phenocode=phenotype?.phenocode?.replace("_EXALLC", "").replace("_EXMORE", "");
-  const hasRisteys=(typeof(phenotype?.hasRisteys) === "boolean") ? phenotype?.hasRisteys         : true;
-  const risteysPhenocode=phenotype?.risteysPhenocode             ? phenotype?.risteysPhenocode   : phenocode;
-  const risteysURLPrefix=phenotype?.risteysURLPrefix             ? phenotype?.risteysURLPrefix   : defaultRisteysURLPrefix;
-  const risteysURL : string=phenotype?.risteysURL                ? phenotype?.risteysURL         : `${risteysURLPrefix}${risteysPhenocode}`;
-  phenotype.risteysURL = hasRisteys ? risteysURL : null;
-  return phenotype;
+  phenotype.risteysURL = risteysURLFormatter(phenotype);
+  return phenotype
 }
 
 export const getPhenotype = (phenotypeCode : string,


### PR DESCRIPTION
This is fixing issue https://github.com/FINNGEN/pheweb/issues/640 . 

This removes the phenotype banner html from configuration and instead constructs it in code. Risteys url/link formatting is done using the existing risteys link functions from the index page. Previously there were two implementations of risteys link formatting.