### PR TITLE
better filenames in several places

### DIFF
--- a/ui/src/components/HLA/HLATable.tsx
+++ b/ui/src/components/HLA/HLATable.tsx
@@ -30,7 +30,7 @@ const defaultSorted = [{
 
 const HLATable = (props) => {
   const prop: DownloadTableProps<HLAModel.Data, HLAModel.Row> = {
-    filename: 'hla.tsv',
+    filename: `${props.filename ?? 'hla.tsv'}`,
     tableData: props.data,
     dataToTableRows: (data) => data,
     tableColumns,

--- a/ui/src/components/Phenotype/PhenotypeCSTable.tsx
+++ b/ui/src/components/Phenotype/PhenotypeCSTable.tsx
@@ -20,7 +20,7 @@ const r2leadThreshold = window?.config?.userInterface?.phenotype?.r2_to_lead_thr
 const PhenotypeCSTable = () => {
   const {  credibleSets , phenotypeCode } = useContext<Partial<PhenotypeState>>(PhenotypeContext);
   const tableData : CredibleSet[] = credibleSets || [];
-  const filename : string = `${phenotypeCode}.tsv`
+  const filename : string = `${phenotypeCode}_credible_sets.tsv`
   const dataToTableRows : (d : CredibleSet[]) => CredibleSet[] = (x => x)
   const tableColumns :  Column<CredibleSet>[] = createTableColumns<CredibleSet>(configuration?.table?.columns) || csTableCols as Column<CredibleSet>[];
   const [locusGroups, setLocusGroups] = useState<LocusGroups>([{}]);

--- a/ui/src/components/Phenotype/PhenotypeTab.tsx
+++ b/ui/src/components/Phenotype/PhenotypeTab.tsx
@@ -47,7 +47,7 @@ const PhenotypeTab = () => {
       { isNonEmptyArray(hlaData) &&
       <TabPanel>
         <div id='hla table' className='phenotype-tab'>
-          <HLATable {...{data: hlaData}}/>
+          <HLATable {...{data: hlaData, filename: `${phenotypeCode}_hla.tsv`}}/>
         </div>
       </TabPanel> }
     </Tabs>

--- a/ui/src/components/Phenotype/PhenotypeVariantTable.tsx
+++ b/ui/src/components/Phenotype/PhenotypeVariantTable.tsx
@@ -25,12 +25,11 @@ const variant = window?.config?.userInterface?.phenotype?.variant;
 const quantitativeTableColumns : Column<PhenotypeVariantRow>[] = createTableColumns<PhenotypeVariantRow>(variant?.quantitative?.table?.columns) || phenotypeQuantitativeTableColumns as Column<PhenotypeVariantRow>[];
 const binaryTableColumns : Column<PhenotypeVariantRow>[] = createTableColumns<PhenotypeVariantRow>(variant?.binary?.table?.columns) || phenotypeBinaryTableColumns as Column<PhenotypeVariantRow>[];
 
-interface Props { phenotypeCode : string }
 const PhenotypeVariantTable = () => {
   const { phenotype , phenotypeCode , phenotypeVariantData } = useContext<Partial<PhenotypeState>>(PhenotypeContext);
   const tableData : PhenotypeVariantData | null = phenotypeVariantData || null;
   const tableColumns = phenotype.is_binary == false?quantitativeTableColumns : binaryTableColumns;
-  const filename : string = `${phenotypeCode}.tsv`
+  const filename : string = `${phenotypeCode}_variants.tsv`
   const props : DownloadTableProps<PhenotypeVariantData, PhenotypeVariantRow>  = {
     filename,
     tableData,

--- a/ui/src/components/Region/Colocalization/ColocalizationList.tsx
+++ b/ui/src/components/Region/Colocalization/ColocalizationList.tsx
@@ -51,7 +51,7 @@ const subComponent = (row : Row<Colocalization>) => {
 }
 
 
-interface Props {}
+interface Props {filename? : string}
 const ColocalizationList = (props : Props) => {
     const { locusZoomData,
             colocalization ,
@@ -186,7 +186,7 @@ const ColocalizationList = (props : Props) => {
                 data={ colocFiltBySource.map(flatten) }
                 separator={'\t'}
                 enclosingCharacter={''}
-                filename={`colocalization.tsv`}
+                filename={props?.filename ??`colocalization.tsv`}
                 className="btn btn-primary"
                 target="_blank">Download Table
             </CSVLink>

--- a/ui/src/components/Region/LocusZoom/RegionLayouts.tsx
+++ b/ui/src/components/Region/LocusZoom/RegionLayouts.tsx
@@ -142,7 +142,8 @@ export const region_layout: (region: Region) => Layout = (region: Region) => {
 						direction: 0.75,
 						group_position: "end" },
 					      { "type": "download",
-						"position": "right" }] },
+						"position": "right",
+						"filename": `${region.phenotype.phenocode}_region_${['chromosome', 'start', 'stop'].map((d) => region.region[d]).join("_")}_locuszoom.svg` }] },
 	    "panels": [] } }
 
 export const association_layout: (region: Region) => Layout = (region: Region) => {

--- a/ui/src/components/Region/RegionColocalization.tsx
+++ b/ui/src/components/Region/RegionColocalization.tsx
@@ -13,7 +13,7 @@ const RegionColocalization =  (props : Props) => {
 
 
     if(config !== null && region) {
-        return (<ColocalizationList/>);
+        return (<ColocalizationList filename={`${region.phenotype.phenocode}_region_${['chromosome', 'start', 'stop'].map((d) => region.region[d]).join("_")}_colocalization.tsv`} />);
     } else {
         return (<div className="col-xs-12"></div>);
     }

--- a/ui/src/components/Variant/VariantLocusZoom.tsx
+++ b/ui/src/components/Variant/VariantLocusZoom.tsx
@@ -284,7 +284,7 @@ const VariantLocusZoom = ({ variantData } : Props ) => {
         },
         dashboard: {
           components: [
-            {type: "download", position: "right", filename: `${['chr','pos','ref','alt'].map((d) => variantData.variant[d]).join("_")}_locuszoom.svg`},
+            {type: "download", position: "right", filename: `${['chr','pos','ref','alt'].map((d) => variantData.variant[d]).join("_")}_phewas_plot.svg`},
           ]
         },
         //height: 200, // doesn't work?

--- a/ui/src/components/Variant/VariantLocusZoom.tsx
+++ b/ui/src/components/Variant/VariantLocusZoom.tsx
@@ -284,7 +284,7 @@ const VariantLocusZoom = ({ variantData } : Props ) => {
         },
         dashboard: {
           components: [
-            {type: "download", position: "right"}
+            {type: "download", position: "right", filename: `${['chr','pos','ref','alt'].map((d) => variantData.variant[d]).join("_")}_locuszoom.svg`},
           ]
         },
         //height: 200, // doesn't work?

--- a/ui/src/components/Variant/VariantTable.tsx
+++ b/ui/src/components/Variant/VariantTable.tsx
@@ -65,7 +65,7 @@ const VariantTable = ({ variantData, getSumstats, activePage } : Props ) => {
       filename,
       tableData,
       dataToTableRows : dataToTableRows(colorByCategory),
-      tableColumns ,
+      tableColumns,
       tableProperties: activePage !== null ? { ...tableProperties, page: activePage }  : tableProperties,
       defaultSorted : defaultSorted,
       getTrProps: getTrProps


### PR DESCRIPTION
This PR fixes issue https://github.com/FINNGEN/pheweb/issues/531.

The issue mentions only variant page locuszoom, but I found other cases also, in locuszooms and downloadtables, where the download file name was too generic and not including the exact phenotype/variant/region. 