### PR TITLE
Improve login

### DIFF
--- a/pheweb/serve/auth.py
+++ b/pheweb/serve/auth.py
@@ -1,11 +1,12 @@
 
 from ..conf_utils import conf
 
-from flask import url_for, redirect, request
+from flask import url_for, redirect, request, session
 from rauth import OAuth2Service
 
 import requests
 import json
+import secrets
 
 # It seems like everything is working without these two lines, and I'm not sure why: (maybe because I installed `requests[security]`?)
 # import urllib3.contrib.pyopenssl
@@ -30,10 +31,13 @@ class GoogleSignIn(object):
         return r.json()
 
     def authorize(self):
+        state = secrets.token_urlsafe(32)
+        session['oauth_state'] = state
         return redirect(self.service.get_authorize_url(
             scope='email',
             response_type='code',
             prompt='select_account',
+            state=state,
             redirect_uri=self.get_callback_url())
         )
 
@@ -43,7 +47,13 @@ class GoogleSignIn(object):
                         _external=True)
 
     def callback(self):
+        expected_state = session.pop('oauth_state', None)
         if 'code' not in request.args:
+            return (None, None)
+        # Guards against CSRF: an attacker tricking a victim into completing
+        # the attacker's own OAuth flow, which would log the victim into the
+        # attacker's account.
+        if not expected_state or request.args.get('state') != expected_state:
             return (None, None)
         # The following two commands pass **kwargs to requests.
         oauth_session = self.service.get_auth_session(

--- a/pheweb/serve/group_based_auth.py
+++ b/pheweb/serve/group_based_auth.py
@@ -71,14 +71,22 @@ def verify_membership(username):
     if cached is not None and now - cached[0] < _MEMBERSHIP_CACHE_TTL_SECONDS:
         return cached[1]
 
-    result = _check_group_membership(username)
+    result, definitive = _check_group_membership(username)
 
-    with _membership_cache_lock:
-        _membership_cache[username] = (now, result)
+    # Only cache a definitive answer. If some group check errored out and we
+    # never found a match, we don't actually know the membership status, so
+    # don't let a transient API failure get cached as "not a member".
+    if definitive:
+        with _membership_cache_lock:
+            _membership_cache[username] = (now, result)
     return result
 
 
 def _check_group_membership(username):
+    """Returns (is_member, definitive). definitive is False if a group check
+    errored out without us finding a match, meaning the result is not known
+    for certain and should not be cached."""
+    definitive = True
     for name in group_names:
         try:
             r = (
@@ -89,8 +97,9 @@ def _check_group_membership(username):
             )
         except HttpError:
             logging.exception("membership check failed for %r in group %r", username, name)
+            definitive = False
             continue
         if r["isMember"] is True:
-            return True
+            return True, True
     # default to false
-    return False
+    return False, definitive

--- a/pheweb/serve/group_based_auth.py
+++ b/pheweb/serve/group_based_auth.py
@@ -1,10 +1,20 @@
 from ..conf_utils import conf
+import logging
 import sys
 import threading
+import time
 from collections import defaultdict
 
 from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
 from google.oauth2 import service_account
+
+# Google group membership rarely changes, but before_request() calls
+# verify_membership() on every request, so cache results per-process for
+# a while to avoid hitting the Admin SDK on every page load.
+_MEMBERSHIP_CACHE_TTL_SECONDS = 300
+_membership_cache = {}
+_membership_cache_lock = threading.Lock()
 
 if conf["authentication"]:
     group_names = conf.group_auth["GROUPS"]
@@ -47,17 +57,6 @@ def get_all_members(group_names):
     return members
 
 
-def get_member_status(username):
-    allmembers = get_all_members(group_names)
-
-    for m in allmembers:
-        user = m["email"]
-        if "gserviceaccount" in user:  # service accounts are excluded
-            continue
-        if user == username:
-            return m["status"]
-
-
 def verify_membership(username):
 
     if username in whitelist:
@@ -65,15 +64,33 @@ def verify_membership(username):
     # auth service .hasMember will only work for accounts of the domain
     elif not username.endswith("@finngen.fi"):
         return False
-    else:
-        for name in group_names:
+
+    now = time.monotonic()
+    with _membership_cache_lock:
+        cached = _membership_cache.get(username)
+    if cached is not None and now - cached[0] < _MEMBERSHIP_CACHE_TTL_SECONDS:
+        return cached[1]
+
+    result = _check_group_membership(username)
+
+    with _membership_cache_lock:
+        _membership_cache[username] = (now, result)
+    return result
+
+
+def _check_group_membership(username):
+    for name in group_names:
+        try:
             r = (
                 services[threading.get_ident()]
                 .members()
                 .hasMember(groupKey=name, memberKey=username)
                 .execute()
             )
-            if r["isMember"] is True:
-                return True
+        except HttpError:
+            logging.exception("membership check failed for %r in group %r", username, name)
+            continue
+        if r["isMember"] is True:
+            return True
     # default to false
     return False

--- a/pheweb/serve/server_auth.py
+++ b/pheweb/serve/server_auth.py
@@ -13,9 +13,10 @@ def before_request():
     if not conf.authentication:
         print('anonymous visited {!r}'.format(request.path))
         return None
-    elif getattr(g, 'is_test', None) == True:
+    elif getattr(g, 'is_test', None) is True:
         return None
-    elif current_user is None or not hasattr(current_user, 'email'):
+    elif current_user.is_anonymous:
+        session['original_destination'] = request.path
         if _is_api_request():
             return jsonify({'status': 'error', 'message': 'not authenticated'}), 401
         return redirect(url_for('get_authorized',

--- a/tests/pheweb/serve/auth_test.py
+++ b/tests/pheweb/serve/auth_test.py
@@ -1,0 +1,160 @@
+# -*- coding: utf-8 -*-
+
+"""
+Unit tests for auth module.
+
+See: pheweb/serve/auth.py
+"""
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask, session
+
+from pheweb.serve import auth as auth_module
+from pheweb.serve.auth import GoogleSignIn
+
+GOOGLE_DISCOVERY_DOC = {
+    "authorization_endpoint": "https://accounts.google.com/o/oauth2/v2/auth",
+    "userinfo_endpoint": "https://openidconnect.googleapis.com/v1/userinfo",
+    "token_endpoint": "https://oauth2.googleapis.com/token",
+}
+
+
+@pytest.fixture(name="app")
+def fixture_app():
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+
+    @app.route("/callback/google")
+    def oauth_callback_google():
+        return "ok"
+
+    return app
+
+
+@pytest.fixture(autouse=True)
+def _conf_login(monkeypatch):
+    monkeypatch.setattr(
+        auth_module.conf,
+        "login",
+        {
+            "GOOGLE_LOGIN_CLIENT_ID": "test-client-id",
+            "GOOGLE_LOGIN_CLIENT_SECRET": "test-client-secret",
+        },
+        raising=False,
+    )
+
+def _bare_sign_in():
+    """
+    A GoogleSignIn instance with __init__ skipped, for tests that only
+    exercise authorize()/callback()/get_callback_url() and want to control
+    `.service` directly rather than building a real OAuth2Service.
+    """
+    instance = GoogleSignIn.__new__(GoogleSignIn)
+    instance.service = MagicMock()
+    return instance
+
+# --- get_callback_url -------------------------------------------------------
+
+def test_get_callback_url(app):
+    sign_in = _bare_sign_in()
+    with app.test_request_context("/"):
+        url = sign_in.get_callback_url()
+    assert url.startswith("https://")
+    assert url.endswith("/callback/google")
+
+
+# --- authorize ---------------------------------------------------------------
+
+def test_authorize_redirects_to_google_and_stores_state(app):
+    sign_in = _bare_sign_in()
+    sign_in.service.get_authorize_url.return_value = "https://accounts.google.com/auth?foo=bar"
+
+    with app.test_request_context("/"):
+        response = sign_in.authorize()
+        assert response.status_code == 302
+        assert response.location == "https://accounts.google.com/auth?foo=bar"
+
+        stored_state = session["oauth_state"]
+        assert stored_state
+
+    kwargs = sign_in.service.get_authorize_url.call_args.kwargs
+    assert kwargs["state"] == stored_state
+    assert kwargs["scope"] == "email"
+    assert kwargs["response_type"] == "code"
+    assert kwargs["prompt"] == "select_account"
+    assert kwargs["redirect_uri"].endswith("/callback/google")
+
+
+def test_authorize_uses_a_fresh_state_each_call(app):
+    sign_in = _bare_sign_in()
+    sign_in.service.get_authorize_url.return_value = "https://accounts.google.com/auth"
+
+    with app.test_request_context("/"):
+        sign_in.authorize()
+        state_1 = session["oauth_state"]
+
+    with app.test_request_context("/"):
+        sign_in.authorize()
+        state_2 = session["oauth_state"]
+
+    assert state_1 != state_2
+
+
+# --- callback ------------------------------------------------------------------
+
+def test_callback_without_code_returns_none(app):
+    sign_in = _bare_sign_in()
+    with app.test_request_context("/callback/google"):
+        assert sign_in.callback() == (None, None)
+
+
+def test_callback_rejects_missing_session_state(app):
+    """No prior authorize() call means no expected state was ever stored."""
+    sign_in = _bare_sign_in()
+    with app.test_request_context("/callback/google?code=abc123&state=whatever"):
+        assert sign_in.callback() == (None, None)
+
+
+def test_callback_rejects_mismatched_state(app):
+    """Guards against CSRF: a forged callback with the wrong state must be rejected."""
+    sign_in = _bare_sign_in()
+    with app.test_request_context("/callback/google?code=abc123&state=wrong"):
+        session["oauth_state"] = "expected"
+        assert sign_in.callback() == (None, None)
+        # the stored state is single-use, consumed even on a failed attempt
+        assert "oauth_state" not in session
+
+
+def test_callback_with_valid_state_returns_name_and_email(app):
+    sign_in = _bare_sign_in()
+    userinfo_response = MagicMock()
+    userinfo_response.json.return_value = {"name": "Alice", "email": "alice@finngen.fi"}
+    oauth_session = MagicMock()
+    oauth_session.get.return_value = userinfo_response
+    sign_in.service.get_auth_session.return_value = oauth_session
+
+    with app.test_request_context("/callback/google?code=abc123&state=expected"):
+        session["oauth_state"] = "expected"
+        result = sign_in.callback()
+
+    assert result == ("Alice", "alice@finngen.fi")
+    call_kwargs = sign_in.service.get_auth_session.call_args.kwargs
+    assert call_kwargs["data"]["code"] == "abc123"
+    assert call_kwargs["data"]["grant_type"] == "authorization_code"
+    assert call_kwargs["data"]["redirect_uri"].endswith("/callback/google")
+
+
+def test_callback_falls_back_to_email_when_name_missing(app):
+    sign_in = _bare_sign_in()
+    userinfo_response = MagicMock()
+    userinfo_response.json.return_value = {"email": "bob@finngen.fi"}
+    oauth_session = MagicMock()
+    oauth_session.get.return_value = userinfo_response
+    sign_in.service.get_auth_session.return_value = oauth_session
+
+    with app.test_request_context("/callback/google?code=abc123&state=expected"):
+        session["oauth_state"] = "expected"
+        result = sign_in.callback()
+
+    assert result == ("bob@finngen.fi", "bob@finngen.fi")

--- a/tests/pheweb/serve/group_based_auth_test.py
+++ b/tests/pheweb/serve/group_based_auth_test.py
@@ -1,0 +1,189 @@
+# -*- coding: utf-8 -*-
+
+"""
+Unit tests for group_based_auth module.
+
+See: pheweb/serve/group_based_auth.py
+"""
+from collections import defaultdict
+from unittest.mock import MagicMock
+
+import pytest
+from googleapiclient.errors import HttpError
+
+from pheweb.serve import group_based_auth
+from pheweb.serve.group_based_auth import (
+    verify_membership,
+    get_all_members,
+    _check_group_membership,
+)
+
+
+def _http_error():
+    """Build a minimal HttpError, as raised by the Google API client."""
+    return HttpError(MagicMock(status=500, reason="boom"), b"{}")
+
+
+def _fake_services(group_outcomes):
+    """
+    Build a fake `services` defaultdict (as used by group_based_auth,
+    keyed by thread id) whose `.members().hasMember(groupKey=...)` calls
+    are driven by `group_outcomes`: a dict mapping group name to either
+    a bool (the `isMember` result) or an Exception instance to raise.
+
+    @param group_outcomes: dict of group name -> bool or Exception
+    @return: (fake services defaultdict, list recording each group name queried)
+    """
+    calls = []
+
+    def has_member(groupKey, memberKey):
+        calls.append(groupKey)
+        outcome = group_outcomes[groupKey]
+        request = MagicMock()
+        if isinstance(outcome, Exception):
+            request.execute.side_effect = outcome
+        else:
+            request.execute.return_value = {"isMember": outcome}
+        return request
+
+    members = MagicMock()
+    members.hasMember.side_effect = has_member
+    service = MagicMock()
+    service.members.return_value = members
+    return defaultdict(lambda: service), calls
+
+
+@pytest.fixture(autouse=True)
+def _clear_membership_cache(monkeypatch):
+    """Every test starts with an empty, isolated membership cache."""
+    monkeypatch.setattr(group_based_auth, "_membership_cache", {})
+
+
+def test_verify_membership_whitelisted(monkeypatch):
+    monkeypatch.setattr(group_based_auth, "whitelist", ["alice@example.com"])
+    monkeypatch.setattr(group_based_auth, "group_names", ["g1"])
+    # services is left as None: touching it would error, proving no API call was made.
+    monkeypatch.setattr(group_based_auth, "services", None)
+    assert verify_membership("alice@example.com") is True
+
+
+def test_verify_membership_non_domain_user_rejected(monkeypatch):
+    monkeypatch.setattr(group_based_auth, "whitelist", [])
+    monkeypatch.setattr(group_based_auth, "group_names", ["g1"])
+    monkeypatch.setattr(group_based_auth, "services", None)
+    assert verify_membership("bob@example.com") is False
+
+
+def test_verify_membership_member_of_second_group(monkeypatch):
+    monkeypatch.setattr(group_based_auth, "whitelist", [])
+    monkeypatch.setattr(group_based_auth, "group_names", ["g1", "g2"])
+    services, calls = _fake_services({"g1": False, "g2": True})
+    monkeypatch.setattr(group_based_auth, "services", services)
+
+    assert verify_membership("carol@finngen.fi") is True
+    assert calls == ["g1", "g2"]
+
+
+def test_verify_membership_not_a_member_of_any_group(monkeypatch):
+    monkeypatch.setattr(group_based_auth, "whitelist", [])
+    monkeypatch.setattr(group_based_auth, "group_names", ["g1", "g2"])
+    services, calls = _fake_services({"g1": False, "g2": False})
+    monkeypatch.setattr(group_based_auth, "services", services)
+
+    assert verify_membership("dave@finngen.fi") is False
+    assert calls == ["g1", "g2"]
+
+
+def test_verify_membership_api_error_fails_closed_but_checks_other_groups(monkeypatch):
+    monkeypatch.setattr(group_based_auth, "whitelist", [])
+    monkeypatch.setattr(group_based_auth, "group_names", ["g1", "g2"])
+    services, calls = _fake_services({"g1": _http_error(), "g2": False})
+    monkeypatch.setattr(group_based_auth, "services", services)
+
+    # A failed check on g1 must not raise, and must not prevent g2 from being checked.
+    assert verify_membership("frank@finngen.fi") is False
+    assert calls == ["g1", "g2"]
+
+
+def test_verify_membership_caches_definitive_result(monkeypatch):
+    monkeypatch.setattr(group_based_auth, "whitelist", [])
+    monkeypatch.setattr(group_based_auth, "group_names", ["g1"])
+    services, calls = _fake_services({"g1": True})
+    monkeypatch.setattr(group_based_auth, "services", services)
+
+    assert verify_membership("grace@finngen.fi") is True
+    assert verify_membership("grace@finngen.fi") is True
+    assert calls == ["g1"]  # second call served from cache, no new API call
+
+
+def test_verify_membership_does_not_cache_inconclusive_result(monkeypatch):
+    """
+    Regression test: if every group check errors out, the result must not be
+    cached, since a transient API failure isn't a real "not a member" answer.
+    Otherwise a brief outage would deny a real member for the whole TTL.
+    """
+    monkeypatch.setattr(group_based_auth, "whitelist", [])
+    monkeypatch.setattr(group_based_auth, "group_names", ["g1"])
+    services, calls = _fake_services({"g1": _http_error()})
+    monkeypatch.setattr(group_based_auth, "services", services)
+
+    assert verify_membership("hank@finngen.fi") is False
+    assert verify_membership("hank@finngen.fi") is False
+    assert calls == ["g1", "g1"]  # not cached: API hit again on the second call
+
+
+def test_verify_membership_cache_expires_after_ttl(monkeypatch):
+    monkeypatch.setattr(group_based_auth, "whitelist", [])
+    monkeypatch.setattr(group_based_auth, "group_names", ["g1"])
+    services, calls = _fake_services({"g1": True})
+    monkeypatch.setattr(group_based_auth, "services", services)
+
+    clock = iter([0, group_based_auth._MEMBERSHIP_CACHE_TTL_SECONDS + 1])
+    monkeypatch.setattr(group_based_auth.time, "monotonic", lambda: next(clock))
+
+    assert verify_membership("iris@finngen.fi") is True
+    assert verify_membership("iris@finngen.fi") is True
+    assert calls == ["g1", "g1"]  # cache had expired, so it re-checked
+
+
+def test_check_group_membership_definitive_when_found(monkeypatch):
+    monkeypatch.setattr(group_based_auth, "group_names", ["g1", "g2"])
+    services, _ = _fake_services({"g1": False, "g2": True})
+    monkeypatch.setattr(group_based_auth, "services", services)
+    assert _check_group_membership("x@finngen.fi") == (True, True)
+
+
+def test_check_group_membership_definitive_when_no_match(monkeypatch):
+    monkeypatch.setattr(group_based_auth, "group_names", ["g1"])
+    services, _ = _fake_services({"g1": False})
+    monkeypatch.setattr(group_based_auth, "services", services)
+    assert _check_group_membership("x@finngen.fi") == (False, True)
+
+
+def test_check_group_membership_inconclusive_on_error(monkeypatch):
+    monkeypatch.setattr(group_based_auth, "group_names", ["g1"])
+    services, _ = _fake_services({"g1": _http_error()})
+    monkeypatch.setattr(group_based_auth, "services", services)
+    assert _check_group_membership("x@finngen.fi") == (False, False)
+
+
+def test_get_all_members(monkeypatch):
+    monkeypatch.setattr(group_based_auth, "group_names", ["g1", "g2"])
+
+    def fake_list(groupKey):
+        request = MagicMock()
+        members_by_group = {
+            "g1": [{"email": "a@finngen.fi"}],
+            "g2": [{"email": "b@finngen.fi"}],
+        }
+        request.execute.return_value = {"members": members_by_group[groupKey]}
+        return request
+
+    members = MagicMock()
+    members.list.side_effect = fake_list
+    service = MagicMock()
+    service.members.return_value = members
+    monkeypatch.setattr(group_based_auth, "services", defaultdict(lambda: service))
+
+    result = get_all_members(["g1", "g2"])
+    assert result == [{"email": "a@finngen.fi"}, {"email": "b@finngen.fi"}]

--- a/tests/pheweb/serve/server_auth_test.py
+++ b/tests/pheweb/serve/server_auth_test.py
@@ -119,6 +119,17 @@ def test_before_request_authorized_member_allowed(app, monkeypatch):
         assert before_request() is None
 
 
+def test_before_request_authorized_member_api_request_allowed(app, monkeypatch):
+    monkeypatch.setattr(server_auth, "current_user", _authenticated_user())
+    monkeypatch.setattr(server_auth, "verify_membership", lambda email: True)
+    with app.test_request_context("/api/drugs/ABC"):
+        # a logged-in, authorized member's API request should pass straight
+        # through: no redirect, no error response, and no destination stashed
+        # in the session since there's nothing to send them back to.
+        assert before_request() is None
+        assert "original_destination" not in session
+
+
 # --- is_public / do_check_auth ---------------------------------------------
 
 def test_is_public_marks_function_and_returns_it_unchanged():

--- a/tests/pheweb/serve/server_auth_test.py
+++ b/tests/pheweb/serve/server_auth_test.py
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*-
+
+"""
+Unit tests for server_auth module.
+
+See: pheweb/serve/server_auth.py
+"""
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask, session, g
+
+from pheweb.serve import server_auth
+from pheweb.serve.server_auth import (
+    _is_api_request,
+    before_request,
+    is_public,
+    do_check_auth,
+)
+
+
+@pytest.fixture(name="app")
+def fixture_app():
+    """A minimal app with the one route before_request() redirects to."""
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+
+    @app.route("/get_authorized")
+    def get_authorized():
+        return "ok"
+
+    return app
+
+
+def _anonymous_user():
+    return SimpleNamespace(is_anonymous=True)
+
+
+def _authenticated_user(email="user@finngen.fi"):
+    return SimpleNamespace(is_anonymous=False, email=email)
+
+
+@pytest.fixture(autouse=True)
+def _default_conf(monkeypatch):
+    """Auth is on by default; individual tests override as needed."""
+    monkeypatch.setattr(server_auth.conf, "authentication", True)
+
+
+# --- _is_api_request -----------------------------------------------------
+
+def test_is_api_request_true(app):
+    with app.test_request_context("/api/drugs/ABC"):
+        assert _is_api_request() is True
+
+
+def test_is_api_request_false(app):
+    with app.test_request_context("/variant/1-2-A-G"):
+        assert _is_api_request() is False
+
+
+# --- before_request --------------------------------------------------------
+
+def test_before_request_allows_all_when_auth_disabled(app, monkeypatch):
+    monkeypatch.setattr(server_auth.conf, "authentication", False)
+    monkeypatch.setattr(server_auth, "current_user", _anonymous_user())
+    with app.test_request_context("/variant/1-2-A-G"):
+        assert before_request() is None
+
+
+def test_before_request_allows_test_requests(app, monkeypatch):
+    monkeypatch.setattr(server_auth, "current_user", _anonymous_user())
+    with app.test_request_context("/variant/1-2-A-G"):
+        g.is_test = True
+        assert before_request() is None
+
+
+def test_before_request_anonymous_user_redirected(app, monkeypatch):
+    monkeypatch.setattr(server_auth, "current_user", _anonymous_user())
+    with app.test_request_context("/variant/1-2-A-G"):
+        response = before_request()
+        assert response.status_code == 302
+        assert "/get_authorized" in response.location
+        assert session["original_destination"] == "/variant/1-2-A-G"
+
+
+def test_before_request_anonymous_api_request_gets_401(app, monkeypatch):
+    monkeypatch.setattr(server_auth, "current_user", _anonymous_user())
+    with app.test_request_context("/api/drugs/ABC"):
+        body, status = before_request()
+        assert status == 401
+        assert body.get_json() == {"status": "error", "message": "not authenticated"}
+        # the destination is still recorded, even though this request can't follow a redirect
+        assert session["original_destination"] == "/api/drugs/ABC"
+
+
+def test_before_request_unauthorized_member_redirected(app, monkeypatch):
+    monkeypatch.setattr(server_auth, "current_user", _authenticated_user())
+    monkeypatch.setattr(server_auth, "verify_membership", lambda email: False)
+    with app.test_request_context("/variant/1-2-A-G"):
+        response = before_request()
+        assert response.status_code == 302
+        assert "/get_authorized" in response.location
+        assert session["original_destination"] == "/variant/1-2-A-G"
+
+
+def test_before_request_unauthorized_api_request_gets_403(app, monkeypatch):
+    monkeypatch.setattr(server_auth, "current_user", _authenticated_user())
+    monkeypatch.setattr(server_auth, "verify_membership", lambda email: False)
+    with app.test_request_context("/api/drugs/ABC"):
+        body, status = before_request()
+        assert status == 403
+        assert body.get_json() == {"status": "error", "message": "not authorized"}
+
+
+def test_before_request_authorized_member_allowed(app, monkeypatch):
+    monkeypatch.setattr(server_auth, "current_user", _authenticated_user())
+    monkeypatch.setattr(server_auth, "verify_membership", lambda email: True)
+    with app.test_request_context("/variant/1-2-A-G"):
+        assert before_request() is None
+
+
+# --- is_public / do_check_auth ---------------------------------------------
+
+def test_is_public_marks_function_and_returns_it_unchanged():
+    def view():
+        return "hi"
+
+    marked = is_public(view)
+    assert marked is view
+    assert marked.is_public is True
+
+
+def test_do_check_auth_skips_before_request_for_public_endpoints(app, monkeypatch):
+    @app.route("/public")
+    @is_public
+    def public_view():
+        return "hi"
+
+    # Even though this would normally be denied, a public endpoint must
+    # bypass before_request() entirely.
+    monkeypatch.setattr(server_auth, "current_user", _anonymous_user())
+    with app.test_request_context("/public"):
+        assert do_check_auth(app) is None
+
+
+def test_do_check_auth_checks_non_public_endpoints(app, monkeypatch):
+    @app.route("/private")
+    def private_view():
+        return "hi"
+
+    monkeypatch.setattr(server_auth, "current_user", _anonymous_user())
+    with app.test_request_context("/private"):
+        response = do_check_auth(app)
+        assert response.status_code == 302
+
+
+def test_do_check_auth_with_unmapped_endpoint_still_checks_auth(app, monkeypatch):
+    monkeypatch.setattr(server_auth, "current_user", _anonymous_user())
+    with app.test_request_context("/no-such-route"):
+        # request.endpoint is None here since no route matched.
+        response = do_check_auth(app)
+        assert response.status_code == 302


### PR DESCRIPTION
This PR fixes a couple of issues in the session management/login

**1. Cache the group membership for each user to avoid querying google auth API on each request**
#636 This should make the login-protected phewebs feel much more responsive than currently. The group memberships are cached for 5 minutes.

**2. Remember the  original url when redirecting into login**
Cuttently, if a logged-out user tries to go to https://r14.finngen.fi/pheno/HEIGHT_IRN, the server redirects the user to google auth login, and after that forgets the original url and redirects the user to the index page.  This is done with the 'original_destination' parameter.

**3. Add state into the OAuth flow to improve security**
Our oauth flow was missing the 'state' parameter, which is a random string generated at our server when starting the login flow. We expect the google auth server to return this same string, to make sure that no one else can iniate login flows on pheweb. 

**4. Handle a possible exception from google auth api**
In case of a temporary error from google auth API, we handle that error and importantly, don't save it to the membership cache.