### PR TITLE
Fix drugdb query

### DIFF
--- a/pheweb/serve/data_access/drug_db.py
+++ b/pheweb/serve/data_access/drug_db.py
@@ -114,38 +114,35 @@ class DrugDao(DrugDB):
             return []
 
         target = hit.get('object') or {}
-        target_classes = [tc['label'] for tc in target.get('targetClass', [])]
-        candidates = target.get('drugAndClinicalCandidates', {}).get('rows', [])
+        target_classes = [tc['label'] for tc in target.get('targetClass', []) if tc]
+        candidates = target['drugAndClinicalCandidates']['rows']
 
         rows = []
         for candidate in candidates:
             drug = candidate.get('drug')
-            # If the candidate has no drug, skip it
-            if not drug:
-                continue
-            mechanisms = [
-                m['mechanismOfAction']
-                for m in drug.get('mechanismsOfAction', {}).get('rows', [])
-                if m.get('mechanismOfAction')
-            ]
-            diseases = [d['disease'] for d in candidate.get('diseases', []) if d.get('disease')]
+            if drug:
+                mechanisms = [
+                    m['mechanismOfAction']
+                    for m in drug.get('mechanismsOfAction', {}).get('rows', [])
+                ]
+                diseases = [d['disease'] for d in candidate['diseases'] if d.get('disease')]
 
-            # deduplicate the diseases here by name, because the API seems to give duplicates on some diseases
-            seen = set()
-            diseases = [d for d in diseases if d['name'] not in seen and not seen.add(d['name'])]
+                # deduplicate the diseases here by name, because the API seems to give duplicates on some diseases
+                seen = set()
+                diseases = [d for d in diseases if d['name'] not in seen and not seen.add(d['name'])]
 
-            for disease in diseases or [{}]:
-                db_xrefs = disease.get('dbXRefs', [])
-                rows.append({
-                    'approvedName': drug.get('name'),
-                    'diseaseName': disease.get('name'),
-                    'EFOInfo': next((x for x in db_xrefs if x.startswith('EFO:')), None),
-                    'drugId': drug.get('id'),
-                    'drugType': drug.get('drugType'),
-                    'maximumClinicalTrialPhase': self._prettify_stage(drug.get('maximumClinicalStage')),
-                    'mechanismOfAction': '; '.join(dict.fromkeys(mechanisms)) or None,
-                    'phase': self._prettify_stage(candidate.get('maxClinicalStage')),
-                    'prefName': drug.get('name'),
-                    'targetClass': target_classes,
-                })
+                for disease in diseases or [{}]:
+                    db_xrefs = disease.get('dbXRefs', [])
+                    rows.append({
+                        'approvedName': drug.get('name'),
+                        'diseaseName': disease.get('name'),
+                        'EFOInfo': next(filter(lambda x: x.startswith("EFO:"),db_xrefs), None),
+                        'drugId': drug.get('id'),
+                        'drugType': drug.get('drugType'),
+                        'maximumClinicalTrialPhase': self._prettify_stage(drug.get('maximumClinicalStage')),
+                        'mechanismOfAction': '; '.join(dict.fromkeys(mechanisms)) or None,
+                        'phase': self._prettify_stage(candidate.get('maxClinicalStage')),
+                        'prefName': drug.get('name'),
+                        'targetClass': target_classes,
+                    })
         return rows

--- a/pheweb/serve/data_access/drug_db.py
+++ b/pheweb/serve/data_access/drug_db.py
@@ -114,7 +114,7 @@ class DrugDao(DrugDB):
             return []
 
         target = hit.get('object') or {}
-        target_classes = [tc['label'] for tc in target.get('targetClass', []) if tc]
+        target_classes = [tc['label'] for tc in target.get('targetClass', [])]
         candidates = target['drugAndClinicalCandidates']['rows']
 
         rows = []

--- a/pheweb/serve/data_access/drug_db.py
+++ b/pheweb/serve/data_access/drug_db.py
@@ -18,7 +18,7 @@ Documentation on how to query :
 """
 
 
-class DrugDB(object):
+class DrugDB(abc.ABC):
     @abc.abstractmethod
     def get_drugs(self, gene) -> object:
         """
@@ -27,206 +27,6 @@ class DrugDB(object):
         @param gene: gene name
         @return: information about drugs associated with the gene
         """
-        raise NotImplementedError
-
-
-def nvl_attribute(name: str, obj: Union[None, Dict], default):
-    """
-    Given an name and a value return
-    the dictionary lookup of the name
-    if the value is a dictionary.
-    The default is returned if not
-    found.
-
-    @param name: name to lookup
-    @param obj: object to look into
-    @param default: value to return if not found.
-    @return: value if found otherwise default
-    """
-    return obj[name] if obj and name in obj else default
-
-
-def copy_attribute(name, src, dst):
-    """
-    Given a name copy attribute from
-    source object to destination object
-    @param name: field name
-    @param src: source object
-    @param dst: destination object
-    @return: destination object
-    """
-    if src and name in src:
-        dst[name] = src[name]
-    return dst
-
-
-def prettify_stage(stage):
-    """
-    Open Targets reports clinical stages as codes like
-    "PHASE_3" or "APPROVAL". Reformat those for display.
-
-    @param stage: raw stage code, or None
-    @return: human-readable stage, or None
-    """
-    return stage.replace('_', ' ').capitalize() if stage else stage
-
-
-def extract_rows(response, gene_name):
-    """
-    The Open Targets schema reports known drugs as a list of
-    drug/target pairs (`drugAndClinicalCandidates`), each with its own
-    list of associated diseases, rather than one flat row per
-    drug-disease evidence entry. Flatten that back into one row per
-    (drug, disease) pair, carrying the target's overall target classes
-    along with each row since they're no longer reported per-drug.
-
-    @param response:
-    @param gene_name:
-    @return: flattened list of drug/disease rows
-    """
-    data = nvl_attribute('data', response, {})
-    search = nvl_attribute('search', data, {})
-    hits = nvl_attribute('hits', search, [])
-    hits = sorted(hits, key=lambda x: x['score'], reverse=True)
-    hit = next((h for h in hits if h['name'] == gene_name), {})
-    target = nvl_attribute('object', hit, {})
-    target_classes = [tc['label'] for tc in nvl_attribute('targetClass', target, []) if tc]
-    candidates = nvl_attribute('drugAndClinicalCandidates', target, {})
-    candidate_rows = nvl_attribute('rows', candidates, [])
-
-    rows = []
-    for candidate in candidate_rows:
-        diseases = [d['disease'] for d in nvl_attribute('diseases', candidate, []) if d.get('disease')]
-        for disease in diseases or [None]:
-            rows.append({
-                'phase': candidate.get('maxClinicalStage'),
-                'targetClass': target_classes,
-                'drug': candidate.get('drug'),
-                'disease': disease,
-            })
-    return rows
-
-
-def reshape_row(row):
-    """
-    The response object needs to be reshaped
-    to a list of rows:
-
-    the fields of the rows are
-
-
-    approvedName: string
-    diseaseName: string
-    drugId: string
-    drugType: string
-    maximumClinicalTrialPhase: string
-    mechanismOfAction: string
-    phase: string
-    prefName: string
-    targetClass: array[string]
-
-
-    @param row:
-    @return: reshaped row
-    """
-    result = {}
-    if row.get('disease'):
-        disease = row['disease']
-        if 'name' in disease:
-            result['diseaseName'] = disease['name']
-        db_xrefs = disease['dbXRefs'] if 'dbXRefs' in disease else []
-        efo_info = next((d for d in db_xrefs if d.startswith('EFO:')), None)
-        if efo_info:
-            result['EFOInfo'] = efo_info
-    if row.get('drug'):
-        drug = row['drug']
-        if 'id' in drug:
-            result['drugId'] = drug['id']
-        if 'name' in drug:
-            # the new schema no longer distinguishes a separate "preferred
-            # name" from the drug's generic name, so both map to it.
-            result['prefName'] = drug['name']
-            result['approvedName'] = drug['name']
-        copy_attribute('drugType', drug, result)
-        if drug.get('maximumClinicalStage'):
-            result['maximumClinicalTrialPhase'] = prettify_stage(drug['maximumClinicalStage'])
-        moa_rows = nvl_attribute('rows', nvl_attribute('mechanismsOfAction', drug, {}), [])
-        mechanisms = [m['mechanismOfAction'] for m in moa_rows if m.get('mechanismOfAction')]
-        if mechanisms:
-            result['mechanismOfAction'] = '; '.join(dict.fromkeys(mechanisms))
-    if row.get('phase'):
-        result['phase'] = prettify_stage(row['phase'])
-    copy_attribute('targetClass', row, result)
-    return result
-
-
-def query_endpoint(gene_name):
-    """
-
-    @param gene_name:
-    @return:
-    """
-    # see : https://platform-docs.opentargets.org/data-access/graphql-api
-    # `knownDrugs` was removed from the schema; known drugs are now reported
-    # per drug/target pair via `drugAndClinicalCandidates`, each with its own
-    # list of associated diseases (see extract_rows for the flattening back
-    # into drug/disease rows).
-    query_string = """
-            query search($gene_name: String!) {
-              search( queryString : $gene_name , entityNames:["target"] ) {
-                hits {
-                  score
-                  name
-                  object {
-                    __typename ... on Target { id
-                    approvedSymbol
-                        approvedName
-                        targetClass { label }
-                        drugAndClinicalCandidates { rows {
-                                            # overall clinical stage reached by this drug against this target
-                                            maxClinicalStage
-                                            drug {
-                                                   id
-                                                   name
-                                                   drugType
-                                                   maximumClinicalStage
-                                                   mechanismsOfAction { rows { mechanismOfAction } }
-                                            }
-                                            diseases {
-                                                disease { dbXRefs , name }
-                                            }
-                        } }
-                    }
-
-                  }
-                }
-              }
-            }
-        """
-    variables = {"gene_name": gene_name}
-    # Set base URL of GraphQL API endpoint
-    base_url = "https://api.platform.opentargets.org/api/v4/graphql"
-
-    # Perform POST request and check status code of response
-    r = requests.post(base_url,
-                      json={"query": query_string, "variables": variables})
-    assert r.status_code == 200, f"failed fetching drugs : ${r}"
-    response = json.loads(r.text)
-    return response
-
-
-def fetch_drugs(gene_name):
-    """
-    fetch drug information for gene.
-
-    @param gene_name: gene name to search for
-    @return: information
-    """
-    response = query_endpoint(gene_name)
-    rows = extract_rows(response, gene_name)
-    rows = list(map(reshape_row, rows))
-    return rows
-
 
 class DrugDao(DrugDB):
     """
@@ -238,13 +38,114 @@ class DrugDao(DrugDB):
     def __init__(self):
         pass
 
+    def _prettify_stage(self, stage):
+        # Open Targets reports clinical stages as codes like "PHASE_3" or
+        # "APPROVAL"; reformat those for display.
+        return stage.replace('_', ' ').capitalize() if stage else None
+
+
+
+    def query_endpoint(self, gene_name):
+        """
+        @param gene_name: gene name to search for
+        @return: response from the GraphQL API
+        """
+        # see : https://platform-docs.opentargets.org/data-access/graphql-api
+        query_string = """
+                query search($gene_name: String!) {
+                  search( queryString : $gene_name , entityNames:["target"] ) {
+                    hits {
+                      score
+                      name
+                      object {
+                        __typename ... on Target { id
+                        approvedSymbol
+                            approvedName
+                            targetClass { label }
+                            drugAndClinicalCandidates { rows {
+                                                # overall clinical stage reached by this drug against this target
+                                                maxClinicalStage
+                                                drug {
+                                                       id
+                                                       name
+                                                       drugType
+                                                       maximumClinicalStage
+                                                       mechanismsOfAction { rows { mechanismOfAction } }
+                                                }
+                                                diseases {
+                                                    disease { dbXRefs , name }
+                                                }
+                            } }
+                        }
+
+                      }
+                    }
+                  }
+                }
+            """
+        variables = {"gene_name": gene_name}
+        # Set base URL of GraphQL API endpoint
+        base_url = "https://api.platform.opentargets.org/api/v4/graphql"
+
+        # Perform POST request and check status code of response
+        r = requests.post(base_url,
+                          json={"query": query_string, "variables": variables})
+        assert r.status_code == 200, f"failed fetching drugs : ${r}"
+        response = json.loads(r.text)
+        return response
+
     def get_drugs(self, gene_name):
         """
-        Get drugs.
+        fetch drug information for gene.
 
-        Get drug information for gene.
-
-        @param gene_name: gene name
-        @return: information if there is any.
+        @param gene_name: gene name to search for
+        @return: information
         """
-        return fetch_drugs(gene_name)
+        response = self.query_endpoint(gene_name)
+        # the API assigns a score for the probability of the hit,
+        # so we take the highest scoring result with the exact gene name match.
+        hits = response.get('data', {}).get('search', {}).get('hits', [])
+        hit = max(
+            (h for h in hits if h.get('name') == gene_name),
+            key=lambda h: h['score'],
+            default=None,
+        )
+        if hit is None:
+            return []
+
+        target = hit.get('object') or {}
+        target_classes = [tc['label'] for tc in target.get('targetClass', []) if tc]
+        candidates = target.get('drugAndClinicalCandidates', {}).get('rows', [])
+
+        rows = []
+        for candidate in candidates:
+            drug = candidate.get('drug')
+            # If the candidate has no drug, skip it
+            if not drug:
+                continue
+            mechanisms = [
+                m['mechanismOfAction']
+                for m in drug.get('mechanismsOfAction', {}).get('rows', [])
+                if m.get('mechanismOfAction')
+            ]
+            diseases = [d['disease'] for d in candidate.get('diseases', []) if d.get('disease')]
+
+            # deduplicate the diseases here by name, because the API seems to give duplicates on some diseases
+            seen = set()
+            diseases = [d for d in diseases if d['name'] not in seen and not seen.add(d['name'])]
+
+            for disease in diseases or [{}]:
+                db_xrefs = disease.get('dbXRefs', [])
+                rows.append({
+                    'approvedName': drug.get('name'),
+                    'diseaseName': disease.get('name'),
+                    'EFOInfo': next((x for x in db_xrefs if x.startswith('EFO:')), None),
+                    'drugId': drug.get('id'),
+                    'drugType': drug.get('drugType'),
+                    'maximumClinicalTrialPhase': self._prettify_stage(drug.get('maximumClinicalStage')),
+                    'mechanismOfAction': '; '.join(dict.fromkeys(mechanisms)) or None,
+                    'phase': self._prettify_stage(candidate.get('maxClinicalStage')),
+                    'prefName': drug.get('name'),
+                    'targetClass': target_classes,
+                })
+        return rows

--- a/pheweb/serve/data_access/drug_db.py
+++ b/pheweb/serve/data_access/drug_db.py
@@ -60,12 +60,29 @@ def copy_attribute(name, src, dst):
     return dst
 
 
+def prettify_stage(stage):
+    """
+    Open Targets reports clinical stages as codes like
+    "PHASE_3" or "APPROVAL". Reformat those for display.
+
+    @param stage: raw stage code, or None
+    @return: human-readable stage, or None
+    """
+    return stage.replace('_', ' ').capitalize() if stage else stage
+
+
 def extract_rows(response, gene_name):
     """
+    The Open Targets schema reports known drugs as a list of
+    drug/target pairs (`drugAndClinicalCandidates`), each with its own
+    list of associated diseases, rather than one flat row per
+    drug-disease evidence entry. Flatten that back into one row per
+    (drug, disease) pair, carrying the target's overall target classes
+    along with each row since they're no longer reported per-drug.
 
     @param response:
     @param gene_name:
-    @return:
+    @return: flattened list of drug/disease rows
     """
     data = nvl_attribute('data', response, {})
     search = nvl_attribute('search', data, {})
@@ -73,8 +90,20 @@ def extract_rows(response, gene_name):
     hits = sorted(hits, key=lambda x: x['score'], reverse=True)
     hit = next((h for h in hits if h['name'] == gene_name), {})
     target = nvl_attribute('object', hit, {})
-    known_drugs = nvl_attribute('knownDrugs', target, {})
-    rows = nvl_attribute('rows', known_drugs, [])
+    target_classes = [tc['label'] for tc in nvl_attribute('targetClass', target, []) if tc]
+    candidates = nvl_attribute('drugAndClinicalCandidates', target, {})
+    candidate_rows = nvl_attribute('rows', candidates, [])
+
+    rows = []
+    for candidate in candidate_rows:
+        diseases = [d['disease'] for d in nvl_attribute('diseases', candidate, []) if d.get('disease')]
+        for disease in diseases or [None]:
+            rows.append({
+                'phase': candidate.get('maxClinicalStage'),
+                'targetClass': target_classes,
+                'drug': candidate.get('drug'),
+                'disease': disease,
+            })
     return rows
 
 
@@ -90,9 +119,9 @@ def reshape_row(row):
     diseaseName: string
     drugId: string
     drugType: string
-    maximumClinicalTrialPhase: number
+    maximumClinicalTrialPhase: string
     mechanismOfAction: string
-    phase: number
+    phase: string
     prefName: string
     targetClass: array[string]
 
@@ -101,7 +130,7 @@ def reshape_row(row):
     @return: reshaped row
     """
     result = {}
-    if 'disease' in row:
+    if row.get('disease'):
         disease = row['disease']
         if 'name' in disease:
             result['diseaseName'] = disease['name']
@@ -109,18 +138,25 @@ def reshape_row(row):
         efo_info = next((d for d in db_xrefs if d.startswith('EFO:')), None)
         if efo_info:
             result['EFOInfo'] = efo_info
-    if 'drug' in row:
+    if row.get('drug'):
         drug = row['drug']
-        copy_attribute('maximumClinicalTrialPhase', drug, result)
-    names = ['approvedName',
-             'drugId',
-             'drugType',
-             'mechanismOfAction',
-             'phase',
-             'prefName',
-             'targetClass']
-    for name in names:
-        copy_attribute(name, row, result)
+        if 'id' in drug:
+            result['drugId'] = drug['id']
+        if 'name' in drug:
+            # the new schema no longer distinguishes a separate "preferred
+            # name" from the drug's generic name, so both map to it.
+            result['prefName'] = drug['name']
+            result['approvedName'] = drug['name']
+        copy_attribute('drugType', drug, result)
+        if drug.get('maximumClinicalStage'):
+            result['maximumClinicalTrialPhase'] = prettify_stage(drug['maximumClinicalStage'])
+        moa_rows = nvl_attribute('rows', nvl_attribute('mechanismsOfAction', drug, {}), [])
+        mechanisms = [m['mechanismOfAction'] for m in moa_rows if m.get('mechanismOfAction')]
+        if mechanisms:
+            result['mechanismOfAction'] = '; '.join(dict.fromkeys(mechanisms))
+    if row.get('phase'):
+        result['phase'] = prettify_stage(row['phase'])
+    copy_attribute('targetClass', row, result)
     return result
 
 
@@ -131,7 +167,10 @@ def query_endpoint(gene_name):
     @return:
     """
     # see : https://platform-docs.opentargets.org/data-access/graphql-api
-    # Build query string
+    # `knownDrugs` was removed from the schema; known drugs are now reported
+    # per drug/target pair via `drugAndClinicalCandidates`, each with its own
+    # list of associated diseases (see extract_rows for the flattening back
+    # into drug/disease rows).
     query_string = """
             query search($gene_name: String!) {
               search( queryString : $gene_name , entityNames:["target"] ) {
@@ -142,26 +181,21 @@ def query_endpoint(gene_name):
                     __typename ... on Target { id
                     approvedSymbol
                         approvedName
-                        knownDrugs { rows {
-                                            # evidence.drug2clinic.clinical_trial_phase.label
-                                            phase
-                                            # target.target_class
-                                            targetClass
-                                            # evidence.target2drug.action_type
-                                            drugType
-                                            drugId
-                                            prefName
-                                            approvedName
-                                            mechanismOfAction
-                                            # disease.efo_info.label
-                                            disease { dbXRefs , name }
+                        targetClass { label }
+                        drugAndClinicalCandidates { rows {
+                                            # overall clinical stage reached by this drug against this target
+                                            maxClinicalStage
                                             drug {
-                                                   # evidence.drug2clinic.max_phase_for_disease.label
-                                                   maximumClinicalTrialPhase ,
-                                                   # drug
+                                                   id
                                                    name
-
-                        } } }
+                                                   drugType
+                                                   maximumClinicalStage
+                                                   mechanismsOfAction { rows { mechanismOfAction } }
+                                            }
+                                            diseases {
+                                                disease { dbXRefs , name }
+                                            }
+                        } }
                     }
 
                   }

--- a/pheweb/serve/data_access/drug_db.py
+++ b/pheweb/serve/data_access/drug_db.py
@@ -114,7 +114,7 @@ class DrugDao(DrugDB):
             return []
 
         target = hit.get('object') or {}
-        target_classes = [tc['label'] for tc in target.get('targetClass', []) if tc]
+        target_classes = [tc['label'] for tc in target.get('targetClass', [])]
         candidates = target.get('drugAndClinicalCandidates', {}).get('rows', [])
 
         rows = []

--- a/tests/pheweb/serve/data_access/drug_db_test.py
+++ b/tests/pheweb/serve/data_access/drug_db_test.py
@@ -234,15 +234,3 @@ def test_get_drugs_joins_deduplicated_mechanisms_of_action():
     rows = dao.get_drugs("PCSK9")
 
     assert rows[0]["mechanismOfAction"] == "Inhibitor; Antagonist"
-
-
-def test_get_drugs_filters_out_falsy_target_classes():
-    target = _target(
-        target_class=[{"label": "Enzyme"}, None],
-        candidates=[_candidate(drug=_drug(), diseases=[_disease("disease A")])],
-    )
-    dao = _dao_with_response(_response([_hit("PCSK9", 1, target)]))
-
-    rows = dao.get_drugs("PCSK9")
-
-    assert rows[0]["targetClass"] == ["Enzyme"]

--- a/tests/pheweb/serve/data_access/drug_db_test.py
+++ b/tests/pheweb/serve/data_access/drug_db_test.py
@@ -6,112 +6,243 @@ Unit test for drug db module.
 See: pheweb/serve/data_access/drug_db.py
 
 """
-import uuid
+import json
 from unittest.mock import patch
 
 import pytest
 
-from pheweb.serve.data_access.drug_db import (
-    nvl_attribute,
-    copy_attribute,
-    query_endpoint,
-    reshape_row,
-    extract_rows, DrugDB, DrugDao, fetch_drugs,
-)
+from pheweb.serve.data_access.drug_db import DrugDB, DrugDao
 
 
-@patch("pheweb.serve.data_access.drug_db.query_endpoint", return_value={})
-def test_fetch_drugs(mock_query_endpoint) -> None:
-    assert fetch_drugs("test") == []
+def _response(hits):
+    return {"data": {"search": {"hits": hits}}}
 
 
-def test_drug_db() -> None:
-    db = DrugDB()
-    with pytest.raises(NotImplementedError):
-        db.get_drugs("")
+def _hit(name, score, target):
+    return {"name": name, "score": score, "object": target}
 
 
-def test_nvl_attribute() -> None:
-    """
-    Test nvl attributes.
-
-    @return: None
-    """
-    assert nvl_attribute("name", None, 1) == 1
-    assert nvl_attribute("name", {}, 1) == 1
-    assert nvl_attribute("name", {"name": 2}, 1) == 2
-
-
-def test_copy_attribute() -> None:
-    """
-    Test copy attribute.
-
-    @return: None
-    """
-    assert copy_attribute("name", None, None) is None
-    assert copy_attribute("name", {}, None) is None
-    assert not copy_attribute("name", {}, {})
-    assert copy_attribute("name", {"name": 1}, {}) == {"name": 1}
-
-
-def test_reshape_row_1() -> None:
-    """
-    Test Reshape row.
-
-    @return: None
-    """
-    assert not reshape_row({})
-    assert reshape_row({"drug": {"name": "aspirin"}}) == {
-        "prefName": "aspirin",
-        "approvedName": "aspirin",
+def _target(target_class=None, candidates=None):
+    return {
+        "targetClass": target_class or [],
+        "drugAndClinicalCandidates": {"rows": candidates or []},
     }
 
 
-def test_reshape_row_2() -> None:
-    """
-    Test reshape row.
-
-    @return: None
-    """
-    assert extract_rows({}, "DBH") == []
-
-
-def test_endpoint() -> None:
-    """
-    Test end point.
-
-    @return: None
-    """
-    assert not query_endpoint("DBH") is None
+def _candidate(drug=None, diseases=None, max_clinical_stage=None):
+    return {
+        "maxClinicalStage": max_clinical_stage,
+        "drug": drug,
+        "diseases": [{"disease": d} for d in (diseases or [])],
+    }
 
 
-@patch("pheweb.serve.data_access.drug_db.fetch_drugs", return_value=None)
-def test_drug_dao_get_drugs(mock_fetch_drugs) -> None:
-    """
-    Test drug dao get drugs.
+def _drug(drug_id="CHEMBL1", name="ASPIRIN", drug_type="Small molecule",
+          max_clinical_stage=None, mechanisms=None):
+    return {
+        "id": drug_id,
+        "name": name,
+        "drugType": drug_type,
+        "maximumClinicalStage": max_clinical_stage,
+        "mechanismsOfAction": {
+            "rows": [{"mechanismOfAction": m} for m in (mechanisms or [])]
+        },
+    }
 
-    :return:
-    """
+
+def _disease(name, db_xrefs=None):
+    return {"name": name, "dbXRefs": db_xrefs or []}
+
+
+def _dao_with_response(response):
     dao = DrugDao()
-    assert dao.get_drugs("test") is None
+    dao.query_endpoint = lambda gene_name: response
+    return dao
 
 
-def test_reshape_row() -> None:
-    row = {}
-    assert reshape_row(row) == {}
-    row['disease'] = {}
-    assert reshape_row(row) == {}
-    name = str(uuid.uuid4())
-    row['disease'] = {'name': name}
-    assert reshape_row(row) == {'diseaseName': name}
-    db_x_ref = str(f'EFO:{uuid.uuid4()}')
-    row['disease'] = {'name': name, 'dbXRefs': [db_x_ref]}
-    assert reshape_row(row) == {'diseaseName': name,
-                                'EFOInfo': db_x_ref}
-    row['drug'] = {'maximumClinicalStage': 'PHASE_3'}
-    assert reshape_row(row) == {'diseaseName': name,
-                                'EFOInfo': db_x_ref,
-                                'maximumClinicalTrialPhase': 'Phase 3'}
+# --- DrugDB / DrugDao ---------------------------------------------------------
+
+def test_drug_db_cannot_be_instantiated_directly():
+    with pytest.raises(TypeError):
+        DrugDB()
 
 
+def test_drug_dao_is_a_drug_db():
+    assert isinstance(DrugDao(), DrugDB)
 
+
+# --- DrugDao.query_endpoint -----------------------------------------------------
+
+def test_query_endpoint_posts_query_and_returns_parsed_response():
+    fixture_response = _response([_hit("DBH", 1, _target())])
+    with patch("pheweb.serve.data_access.drug_db.requests.post") as mock_post:
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.text = json.dumps(fixture_response)
+
+        response = DrugDao().query_endpoint("DBH")
+
+    assert response == fixture_response
+    _, kwargs = mock_post.call_args
+    assert mock_post.call_args.args[0] == "https://api.platform.opentargets.org/api/v4/graphql"
+    assert kwargs["json"]["variables"] == {"gene_name": "DBH"}
+    assert "drugAndClinicalCandidates" in kwargs["json"]["query"]
+
+
+def test_query_endpoint_raises_on_non_200_response():
+    with patch("pheweb.serve.data_access.drug_db.requests.post") as mock_post:
+        mock_post.return_value.status_code = 400
+        mock_post.return_value.text = "{}"
+        with pytest.raises(AssertionError):
+            DrugDao().query_endpoint("DBH")
+
+
+# --- DrugDao._prettify_stage -----------------------------------------------------
+
+def test_prettify_stage_none_stays_none():
+    # This is important because the API might give us None values
+    assert DrugDao()._prettify_stage(None) is None
+
+def test_prettify_stage_formats_phase_codes():
+    dao = DrugDao()
+    assert dao._prettify_stage("PHASE_3") == "Phase 3"
+    assert dao._prettify_stage("APPROVAL") == "Approval"
+
+
+# --- DrugDao.get_drugs -----------------------------------------------------------
+
+def test_get_drugs_empty_response_returns_no_rows():
+    dao = _dao_with_response({})
+    assert dao.get_drugs("PCSK9") == []
+
+
+def test_get_drugs_no_matching_hit_returns_no_rows():
+    dao = _dao_with_response(_response([_hit("SOMEOTHERGENE", 10, _target())]))
+    assert dao.get_drugs("PCSK9") == []
+
+
+def test_get_drugs_picks_the_highest_scoring_matching_hit():
+    low_score_target = _target(candidates=[_candidate(drug=_drug(name="LOW_SCORE_DRUG"))])
+    high_score_target = _target(candidates=[_candidate(drug=_drug(name="HIGH_SCORE_DRUG"))])
+    dao = _dao_with_response(_response([
+        _hit("PCSK9", 1, low_score_target),
+        _hit("PCSK9", 99, high_score_target),
+    ]))
+
+    rows = dao.get_drugs("PCSK9")
+
+    assert len(rows) == 1
+    assert rows[0]["approvedName"] == "HIGH_SCORE_DRUG"
+
+
+def test_get_drugs_candidate_without_a_drug_is_skipped():
+    target = _target(candidates=[_candidate(drug=None, diseases=[_disease("some disease")])])
+    dao = _dao_with_response(_response([_hit("PCSK9", 1, target)]))
+    assert dao.get_drugs("PCSK9") == []
+
+
+def test_get_drugs_maps_a_full_row():
+    drug = _drug(
+        drug_id="CHEMBL3137349",
+        name="BOCOCIZUMAB",
+        drug_type="Antibody",
+        max_clinical_stage="PHASE_3",
+        mechanisms=["Subtilisin/kexin type 9 inhibitor"],
+    )
+    disease = _disease("hyperlipidemia", db_xrefs=["MESH:D006949", "EFO:0004911"])
+    target = _target(
+        target_class=[{"label": "Enzyme"}, {"label": "Protease"}],
+        candidates=[_candidate(drug=drug, diseases=[disease], max_clinical_stage="PHASE_3")],
+    )
+    dao = _dao_with_response(_response([_hit("PCSK9", 1, target)]))
+
+    rows = dao.get_drugs("PCSK9")
+
+    assert rows == [{
+        "approvedName": "BOCOCIZUMAB",
+        "diseaseName": "hyperlipidemia",
+        "EFOInfo": "EFO:0004911",
+        "drugId": "CHEMBL3137349",
+        "drugType": "Antibody",
+        "maximumClinicalTrialPhase": "Phase 3",
+        "mechanismOfAction": "Subtilisin/kexin type 9 inhibitor",
+        "phase": "Phase 3",
+        "prefName": "BOCOCIZUMAB",
+        "targetClass": ["Enzyme", "Protease"],
+    }]
+
+
+def test_get_drugs_emits_one_row_per_disease():
+    drug = _drug()
+    target = _target(candidates=[_candidate(
+        drug=drug,
+        diseases=[_disease("disease A"), _disease("disease B")],
+    )])
+    dao = _dao_with_response(_response([_hit("PCSK9", 1, target)]))
+
+    rows = dao.get_drugs("PCSK9")
+
+    assert [r["diseaseName"] for r in rows] == ["disease A", "disease B"]
+    assert all(r["drugId"] == drug["id"] for r in rows)
+
+
+def test_get_drugs_deduplicates_repeated_diseases():
+    target = _target(candidates=[_candidate(
+        drug=_drug(),
+        diseases=[_disease("disease A"), _disease("disease A")],
+    )])
+    dao = _dao_with_response(_response([_hit("PCSK9", 1, target)]))
+
+    rows = dao.get_drugs("PCSK9")
+
+    assert len(rows) == 1
+    assert rows[0]["diseaseName"] == "disease A"
+
+
+def test_get_drugs_candidate_with_no_diseases_still_emits_a_row():
+    target = _target(candidates=[_candidate(drug=_drug(name="SOLO_DRUG"), diseases=[])])
+    dao = _dao_with_response(_response([_hit("PCSK9", 1, target)]))
+
+    rows = dao.get_drugs("PCSK9")
+
+    assert len(rows) == 1
+    assert rows[0]["approvedName"] == "SOLO_DRUG"
+    assert rows[0]["diseaseName"] is None
+    assert rows[0]["EFOInfo"] is None
+
+
+def test_get_drugs_missing_optional_fields_become_none():
+    drug = {"id": "CHEMBL1", "name": "PLAINDRUG"}  # no drugType, no stage, no mechanisms
+    target = _target(candidates=[_candidate(drug=drug, diseases=[_disease("disease A")])])
+    dao = _dao_with_response(_response([_hit("PCSK9", 1, target)]))
+
+    rows = dao.get_drugs("PCSK9")
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["drugType"] is None
+    assert row["maximumClinicalTrialPhase"] is None
+    assert row["mechanismOfAction"] is None
+    assert row["phase"] is None
+    assert row["EFOInfo"] is None
+
+
+def test_get_drugs_joins_deduplicated_mechanisms_of_action():
+    drug = _drug(mechanisms=["Inhibitor", "Antagonist", "Inhibitor"])
+    target = _target(candidates=[_candidate(drug=drug, diseases=[_disease("disease A")])])
+    dao = _dao_with_response(_response([_hit("PCSK9", 1, target)]))
+
+    rows = dao.get_drugs("PCSK9")
+
+    assert rows[0]["mechanismOfAction"] == "Inhibitor; Antagonist"
+
+
+def test_get_drugs_filters_out_falsy_target_classes():
+    target = _target(
+        target_class=[{"label": "Enzyme"}, None],
+        candidates=[_candidate(drug=_drug(), diseases=[_disease("disease A")])],
+    )
+    dao = _dao_with_response(_response([_hit("PCSK9", 1, target)]))
+
+    rows = dao.get_drugs("PCSK9")
+
+    assert rows[0]["targetClass"] == ["Enzyme"]

--- a/tests/pheweb/serve/data_access/drug_db_test.py
+++ b/tests/pheweb/serve/data_access/drug_db_test.py
@@ -61,7 +61,10 @@ def test_reshape_row_1() -> None:
     @return: None
     """
     assert not reshape_row({})
-    assert reshape_row({"approvedName": 1}) == {"approvedName": 1}
+    assert reshape_row({"drug": {"name": "aspirin"}}) == {
+        "prefName": "aspirin",
+        "approvedName": "aspirin",
+    }
 
 
 def test_reshape_row_2() -> None:
@@ -73,10 +76,6 @@ def test_reshape_row_2() -> None:
     assert extract_rows({}, "DBH") == []
 
 
-@pytest.mark.known_failure
-# TODO(FINNGEN/pheweb#619): query_endpoint asks Open Targets for a `knownDrugs` field
-# on `Target`, which no longer exists in their schema, so the query always fails.
-# Fix the query in pheweb/serve/data_access/drug_db.py, then drop this marker.
 def test_endpoint() -> None:
     """
     Test end point.
@@ -109,11 +108,10 @@ def test_reshape_row() -> None:
     row['disease'] = {'name': name, 'dbXRefs': [db_x_ref]}
     assert reshape_row(row) == {'diseaseName': name,
                                 'EFOInfo': db_x_ref}
-    drug = str(uuid.uuid4())
-    row['drug'] = { 'maximumClinicalTrialPhase' : drug }
+    row['drug'] = {'maximumClinicalStage': 'PHASE_3'}
     assert reshape_row(row) == {'diseaseName': name,
                                 'EFOInfo': db_x_ref,
-                                'maximumClinicalTrialPhase': drug}
+                                'maximumClinicalTrialPhase': 'Phase 3'}
 
 
 

--- a/ui/src/common/commonTableColumn.tsx
+++ b/ui/src/common/commonTableColumn.tsx
@@ -1181,7 +1181,7 @@ const phenotypeColumns = {
     },
     disease: {
       Header: () => (<span style={{ textDecoration: "underline" }}>disease</span>),
-      accessor: "disease",
+      accessor: "diseaseName",
       filterMethod: (filter, row) => row[filter.id] <= filter.value,
       Cell: textCellFormatter
     },
@@ -1196,7 +1196,7 @@ const phenotypeColumns = {
       accessor: "drugId",
       filterMethod: (filter, row) => row[filter.id] <= filter.value,
       Cell: props => props.value === "NA" ? props.value : (
-        <a href={`https://www.ebi.ac.uk/chembl/g/#search_results/all/query=${props.value}`}
+        <a href={`https://www.ebi.ac.uk/chembl/explore/compound/${props.value}`}
            target="_blank" rel="noopener noreferrer">
           {props.value}
         </a>


### PR DESCRIPTION
OpenTargets drug API changed their schema for graphql queries, so needed to adjust the drug query. Decided to rewrite it mostly, because the incoming data format changed so much that adjusting the old code would've made the solution clumsier. Also the tests are new.

IDH1, IDH2 and PTGS2 are examples of genes that have drug info to show.