### PR TITLE
Fix tabix read

### DIFF
--- a/pheweb/serve/data_access/db.py
+++ b/pheweb/serve/data_access/db.py
@@ -2,49 +2,36 @@
 import abc
 import attr
 import copy
-from importlib import import_module
+import importlib
 from collections import defaultdict
 from elasticsearch import Elasticsearch
 import json
 import pysam
 import re
-import math
-import threading
 import pandas as pd
 import numpy as np
 import pymysql
 from typing import List, Tuple, Dict, Union, Optional, Any, Iterable, Final
-from ...file_utils import MatrixReader, common_filepaths
-from ...utils import get_phenolist, get_gene_tuples, pvalue_to_mlogp, mlogp_to_pvalue, get_p_and_mlogp, get_use_phenocode_pheno_map, parse_chromosome
-from ..components.health.health_check import default_dao as health_default_dao, HealthSimpleDAO, HealthNotificationDAO, HealthTrivialDAO
+from ...file_utils import common_filepaths
+from ...utils import get_phenolist, get_gene_tuples, pvalue_to_mlogp, get_p_and_mlogp, get_use_phenocode_pheno_map, parse_chromosome
+from ..components.health.health_check import default_dao as health_default_dao
 from pheweb.serve.components.autocomplete.sqlite_dao import GeneAliasesSqliteDAO
 from pheweb.serve.data_access.gene_info import NCBIGeneInfoDao
 from collections import namedtuple
 import requests
 import importlib
 import gzip
-import subprocess
 import time
-import io
 import os
-import subprocess
 import sys
-import glob
-from pheweb.serve.components.colocalization.model_orm_db import ColocalizationDAO
-from pheweb.serve.components.colocalization.model_sql_db import ColocalizationV2DAO
-from .variant_phenotype import  VariantPhenotypeDao
-from ..components.chip.fs_storage import FileChipDAO
-from ..components.coding.fs_storage import FileCodingDAO
+import logging
 from pathlib import Path
-from .drug_db import DrugDB, DrugDao
-from ..components.autocomplete.tries_dao import AutocompleterTriesDAO
-from ..components.autocomplete.sqlite_dao import AutocompleterSqliteDAO
-from ..components.autocomplete.mysql_dao import AutocompleterMYSQLDAO
-from pheweb.serve.data_access.file import FilePathResultDao, ManhattanFileResultDao, ManhattanCompressedResultDao
+from .drug_db import DrugDao
 from pheweb.serve.data_access.db_util import MysqlDAO
 
-from .pqtl_colocalization import PqtlColocalisationDao
 from ...load_source.load_source import load_source
+
+logger = logging.getLogger(__name__)
 
 class JSONifiable(object):
     @abc.abstractmethod
@@ -693,7 +680,7 @@ class MissingVariantDao(MissingVariantDB):
         self.colnames = [h.lower() for h in self.headers]
 
     def get_missing_variant(self, variant: Variant):
-        for row in self.tabix_file.fetch(f"{variant.chr}", start=variant.pos - 1, end=variant.pos + 1):
+        for row in self.tabix_file.fetch(f"{variant.chr}", start=max(variant.pos - 1, 0), end=variant.pos + 1):
             columns = row.split("\t")
             if columns[self.header_index["Variant"]] == variant.varid:
                 json_obj = dict(zip(self.colnames, columns))
@@ -727,7 +714,7 @@ class TabixGnomadDao(GnomadDB):
             )
 
             tabix_iter = tabix.fetch(
-               fetch_chr, variant.pos - 1, variant.pos)
+               fetch_chr, max(variant.pos - 1, 0), variant.pos)
 
             for row in tabix_iter:
                 split = row.split("\t")
@@ -765,7 +752,7 @@ class TabixGnomadDao(GnomadDB):
         # gnomAD annotation still has X and not 23
         chrom = "X" if str(chrom) == "23" else chrom
         try:
-            tabix_iter = pysam.TabixFile(self.matrix_path).fetch(chrom, start - 1, end)
+            tabix_iter = pysam.TabixFile(self.matrix_path).fetch(chrom, max(start - 1, 0), end)
         except ValueError:
             print(
                 "No variants in the given range. {}:{}-{}".format(chrom, start - 1, end)
@@ -834,7 +821,12 @@ class TabixResultLongDao(ResultDB):
         with pysam.TabixFile(self.matrix_path) as tbx_file:
             if isinstance(chrom, str):
                 chrom = parse_chromosome(chrom)
-            tabix_iter = tbx_file.fetch(chrom, start - 1, end)
+            try:
+                tabix_iter = tbx_file.fetch(chrom, max(start - 1, 0), end)
+            except ValueError:
+                # Tabix throws an error if the chromosome does not exist in the result file
+                logger.warning(f"Chromosome {chrom} does not exist in the variant file {self.matrix_path}.")
+                return []
             # reverse the columns to get a mapping from file to standard column names
             columns_reverse = {v:k for k,v in self.columns.items()}
             results = defaultdict(list)
@@ -914,7 +906,12 @@ class TabixResultLongDao(ResultDB):
             return False
         header_index = {a:i for i,a in enumerate(self.sites_header)}
         with pysam.TabixFile(self.sites_gz_path) as tbx_file:
-            tabix_iter = tbx_file.fetch(variant.chr, variant.pos - 1, variant.pos)
+            try:
+                tabix_iter = tbx_file.fetch(variant.chr, max(variant.pos - 1, 0), variant.pos)
+            except ValueError:
+                # Tabix throws a ValueError if the chromosome does not exist in the variant file
+                logger.warning(f"Chromosome {variant.chr} does not exist in the variant file {self.sites_gz_path}.")
+                return False
             for line in tabix_iter:
                 split = line.split("\t")
                 ref = split[header_index["ref"]]
@@ -1021,7 +1018,7 @@ class ExternalMatrixResultDao(ExternalResultDB):
 
                 try:
                     iter = tabix.fetch(
-                        var.chrom, var.pos - 1, var.pos
+                        var.chrom, max(var.pos - 1, 0), var.pos
                     )
                     for ext_var in iter:
                         ext_var = ext_var.split("\t")
@@ -1056,7 +1053,7 @@ class ExternalMatrixResultDao(ExternalResultDB):
         if known_range is not None:
 
             iter = pysam.TabixFile(self.matrix, parser=None).fetch(
-                "chr" + known_range[0], known_range[1] - 1, known_range[2]
+                "chr" + known_range[0], max(known_range[1] - 1, 0), known_range[2]
             )
 
             for ext_var in iter:
@@ -1097,7 +1094,7 @@ class ExternalMatrixResultDao(ExternalResultDB):
                 try:
                     ## todo remove CHR when annotations fixed
                     iter = tabix.fetch(
-                        "chr" + str(var.chr), var.pos - 1, var.pos,
+                        "chr" + str(var.chr), max(var.pos - 1, 0), var.pos,
                     )
 
                     #iter = self.tabixfiles[threading.get_ident()].fetch(
@@ -1209,7 +1206,7 @@ class ExternalFileResultDao(ExternalResultDB):
         if phenotype in self.results:
             manifestdata = self.results[phenotype]
             tabf = pysam.TabixFile(manifestdata.file, parser=None)
-            tabix_iter = tabf.fetch("chr" + chrom, start - 1, stop)
+            tabix_iter = tabf.fetch("chr" + chrom, max(start - 1, 0), stop)
             for var in tabix_iter:
                 var = var.split("\t")
                 varid = [
@@ -1256,7 +1253,7 @@ class ExternalFileResultDao(ExternalResultDB):
                     .replace("24", "Y")
                     .replace("25", "MT")
                 )
-                iterator = tabf.fetch(fetch_chr, var.pos - 1, var.pos)
+                iterator = tabf.fetch(fetch_chr, max(var.pos - 1, 0), var.pos)
                 for ext_var in iterator:
                     ext_split = ext_var.split("\t")
                     ### TODO: remove this once the datafiles have been regenerated
@@ -1421,7 +1418,7 @@ class TabixAnnotationDao(AnnotationDB):
                 .replace("Y", "25")
             )
 
-            tabix_iter = tabixf.fetch(fetch_chr, variant.pos - 1, variant.pos)
+            tabix_iter = tabixf.fetch(fetch_chr, max(variant.pos - 1, 0), variant.pos)
 
             while True:
                 try:
@@ -1460,7 +1457,7 @@ class TabixAnnotationDao(AnnotationDB):
 
         chrom = "23" if chrom == "X" else chrom
         try:
-            tabix_iter =pysam.TabixFile(self.matrix_path, parser=None).fetch(chrom, start - 1, end)
+            tabix_iter =pysam.TabixFile(self.matrix_path, parser=None).fetch(chrom, max(start - 1, 0), end)
         except ValueError:
             print(
                 "No variants in the given range. {}:{}-{}".format(chrom, start - 1, end)
@@ -1499,7 +1496,7 @@ class TabixAnnotationDao(AnnotationDB):
             self.last_time = time.time()
         try:
             tabix_iter =  pysam.TabixFile(self.matrix_path, parser=None).fetch(
-                chrom.replace("X", "23"), start - 1, end)
+                chrom.replace("X", "23"), max(start - 1, 0), end)
         except Exception as e:
             print("Error occurred {}".format(e))
             return annotations

--- a/pheweb/serve/data_access/db.py
+++ b/pheweb/serve/data_access/db.py
@@ -2,7 +2,7 @@
 import abc
 import attr
 import copy
-import importlib
+from importlib import import_module
 from collections import defaultdict
 from elasticsearch import Elasticsearch
 import json
@@ -12,9 +12,9 @@ import pandas as pd
 import numpy as np
 import pymysql
 from typing import List, Tuple, Dict, Union, Optional, Any, Iterable, Final
-from ...file_utils import common_filepaths
-from ...utils import get_phenolist, get_gene_tuples, pvalue_to_mlogp, get_p_and_mlogp, get_use_phenocode_pheno_map, parse_chromosome
-from ..components.health.health_check import default_dao as health_default_dao
+from ...file_utils import MatrixReader, common_filepaths
+from ...utils import get_phenolist, get_gene_tuples, pvalue_to_mlogp, mlogp_to_pvalue, get_p_and_mlogp, get_use_phenocode_pheno_map, parse_chromosome
+from ..components.health.health_check import default_dao as health_default_dao, HealthSimpleDAO, HealthNotificationDAO, HealthTrivialDAO
 from pheweb.serve.components.autocomplete.sqlite_dao import GeneAliasesSqliteDAO
 from pheweb.serve.data_access.gene_info import NCBIGeneInfoDao
 from collections import namedtuple
@@ -25,10 +25,20 @@ import time
 import os
 import sys
 import logging
+from pheweb.serve.components.colocalization.model_orm_db import ColocalizationDAO
+from pheweb.serve.components.colocalization.model_sql_db import ColocalizationV2DAO
+from .variant_phenotype import  VariantPhenotypeDao
+from ..components.chip.fs_storage import FileChipDAO
+from ..components.coding.fs_storage import FileCodingDAO
 from pathlib import Path
-from .drug_db import DrugDao
+from .drug_db import DrugDB, DrugDao
+from ..components.autocomplete.tries_dao import AutocompleterTriesDAO
+from ..components.autocomplete.sqlite_dao import AutocompleterSqliteDAO
+from ..components.autocomplete.mysql_dao import AutocompleterMYSQLDAO
+from pheweb.serve.data_access.file import FilePathResultDao, ManhattanFileResultDao, ManhattanCompressedResultDao
 from pheweb.serve.data_access.db_util import MysqlDAO
 
+from .pqtl_colocalization import PqtlColocalisationDao
 from ...load_source.load_source import load_source
 
 logger = logging.getLogger(__name__)

--- a/tests/pheweb/serve/data_access/db_test.py
+++ b/tests/pheweb/serve/data_access/db_test.py
@@ -209,6 +209,14 @@ class TestTabixResultLongDao(unittest.TestCase):
         results = tabix_results.get_variants_results([variant_not_found])
         self.assertEqual(results, [])
     
+    def test_variants_results_returns_empty_list_if_chromosome_not_found(self):
+        tabix_results = TabixResultLongDao(
+            self.mocked_pheno_list_data, test_data_file_path, test_mocked_columns, mock_sites_file_path
+        )
+        variant_not_found = Variant("25", "13668", "G", "C")
+        results = tabix_results.get_variants_results([variant_not_found])
+        self.assertEqual(results, [])
+
     def test_variant_range_returns_empty_list_if_not_found(self):
         tabix_results = TabixResultLongDao(
             self.mocked_pheno_list_data, test_data_file_path, test_mocked_columns, mock_sites_file_path
@@ -336,6 +344,11 @@ class TestTabixResultLongDao(unittest.TestCase):
         dao = TabixResultLongDao(self.mocked_pheno_list_data, test_data_file_path, test_mocked_columns,mock_sites_file_path)
         self.assertFalse(dao._variant_exists(variant))
     
+    def test_non_existing_chromosome_returns_false(self):
+        variant = Variant("25", "14842", "G", "T")
+        dao = TabixResultLongDao(self.mocked_pheno_list_data, test_data_file_path, test_mocked_columns,mock_sites_file_path)
+        self.assertFalse(dao._variant_exists(variant))
+
     def test_variant_corner_cases(self):
         one_before = Variant("1", "14841", "G", "A")
         variant = Variant("1", "14842", "G", "T")
@@ -360,12 +373,9 @@ class TestTabixResultLongDao(unittest.TestCase):
             self.assertEqual(res.maf, None)
             self.assertEqual(res.maf_case, None)
             self.assertEqual(res.maf_control, None)
-    
-    @pytest.mark.known_failure
-    # TODO: the X/23 range queries return the wrong number of rows against
-    # tests/mocked-data/sites_mocked.tsv.gz. Either chromosome normalisation in
-    # TabixResultLongDao is wrong for X, or the mocked data lacks the X rows.
-    def test_chromosome_X(self):
+
+    def test_chromosome_X_Y(self):
+        # This tests the translations from letter to numbers in chromosome names. X exists in the data, Y does not.
         tabix_results = TabixResultLongDao(
             self.mocked_pheno_list_data, test_data_file_path, test_mocked_columns, mock_sites_file_path
         )


### PR DESCRIPTION
Fixing https://github.com/FINNGEN/pheweb/issues/597, which was caused by pad-gene function setting the tabix-queried region start to 0, and all tabix read calls applying -1 to the read start. After this there was another issue, which was already flagged in tests. Chromosomes that are not present in the variant file throw ValueError, instead of an empty list, when read with tabix. This is a tabix feature, but for simplicity in use changed the TabixLongReader class to handle the value error and return empty list, or false in case of 'variant exists' query. Added a few tests for missing chromosome cases.

I added max(start-1, 0) to all places in db.py where tabix.fetch is being used. It should always be done, right?

Also while I was there, removed some unused imports.